### PR TITLE
feat: add Zustand game store with localStorage persistence

### DIFF
--- a/src/store/gameStore.test.ts
+++ b/src/store/gameStore.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { initialGameState, useGameStore } from "./gameStore";
+
+beforeEach(() => {
+  localStorage.clear();
+  useGameStore.setState(initialGameState);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("gameStore", () => {
+  describe("initial state", () => {
+    it("has correct default values", () => {
+      const state = useGameStore.getState();
+      expect(state.trainingData).toBe(0);
+      expect(state.totalClicks).toBe(0);
+      expect(state.evolutionStage).toBe(0);
+      expect(state.lastSaved).toBe(0);
+    });
+  });
+
+  describe("clickFeed", () => {
+    it("increments trainingData by 1", () => {
+      useGameStore.getState().clickFeed();
+      expect(useGameStore.getState().trainingData).toBe(1);
+    });
+
+    it("increments totalClicks by 1", () => {
+      useGameStore.getState().clickFeed();
+      expect(useGameStore.getState().totalClicks).toBe(1);
+    });
+
+    it("updates lastSaved timestamp", () => {
+      const before = Date.now();
+      useGameStore.getState().clickFeed();
+      const after = Date.now();
+      const { lastSaved } = useGameStore.getState();
+      expect(lastSaved).toBeGreaterThanOrEqual(before);
+      expect(lastSaved).toBeLessThanOrEqual(after);
+    });
+
+    it("accumulates across multiple clicks", () => {
+      useGameStore.getState().clickFeed();
+      useGameStore.getState().clickFeed();
+      useGameStore.getState().clickFeed();
+      const state = useGameStore.getState();
+      expect(state.trainingData).toBe(3);
+      expect(state.totalClicks).toBe(3);
+    });
+
+    it("does not affect evolutionStage", () => {
+      useGameStore.getState().clickFeed();
+      expect(useGameStore.getState().evolutionStage).toBe(0);
+    });
+  });
+
+  describe("addTrainingData", () => {
+    it("adds the specified amount to trainingData", () => {
+      useGameStore.getState().addTrainingData(100);
+      expect(useGameStore.getState().trainingData).toBe(100);
+    });
+
+    it("does not affect totalClicks", () => {
+      useGameStore.getState().addTrainingData(50);
+      expect(useGameStore.getState().totalClicks).toBe(0);
+    });
+
+    it("updates lastSaved timestamp", () => {
+      const before = Date.now();
+      useGameStore.getState().addTrainingData(10);
+      const after = Date.now();
+      const { lastSaved } = useGameStore.getState();
+      expect(lastSaved).toBeGreaterThanOrEqual(before);
+      expect(lastSaved).toBeLessThanOrEqual(after);
+    });
+
+    it("accumulates with existing trainingData", () => {
+      useGameStore.getState().addTrainingData(10);
+      useGameStore.getState().addTrainingData(20);
+      expect(useGameStore.getState().trainingData).toBe(30);
+    });
+
+    it("works with fractional amounts", () => {
+      useGameStore.getState().addTrainingData(0.5);
+      useGameStore.getState().addTrainingData(0.3);
+      expect(useGameStore.getState().trainingData).toBeCloseTo(0.8);
+    });
+
+    it("combines correctly with clickFeed", () => {
+      useGameStore.getState().clickFeed();
+      useGameStore.getState().clickFeed();
+      useGameStore.getState().addTrainingData(100);
+      const state = useGameStore.getState();
+      expect(state.trainingData).toBe(102);
+      expect(state.totalClicks).toBe(2);
+    });
+  });
+});

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface GameState {
+  trainingData: number;
+  totalClicks: number;
+  evolutionStage: number;
+  lastSaved: number;
+}
+
+interface GameActions {
+  clickFeed: () => void;
+  addTrainingData: (amount: number) => void;
+}
+
+export type GameStore = GameState & GameActions;
+
+export const initialGameState: GameState = {
+  trainingData: 0,
+  totalClicks: 0,
+  evolutionStage: 0,
+  lastSaved: 0,
+};
+
+export const useGameStore = create<GameStore>()(
+  persist(
+    (set) => ({
+      ...initialGameState,
+      clickFeed: () =>
+        set((state) => ({
+          trainingData: state.trainingData + 1,
+          totalClicks: state.totalClicks + 1,
+          lastSaved: Date.now(),
+        })),
+      addTrainingData: (amount) =>
+        set((state) => ({
+          trainingData: state.trainingData + amount,
+          lastSaved: Date.now(),
+        })),
+    }),
+    {
+      name: "glorp-game-state",
+    },
+  ),
+);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,2 @@
+export type { GameStore } from "./gameStore";
+export { initialGameState, useGameStore } from "./gameStore";

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,30 @@
+const store: Record<string, string> = {};
+
+const storageMock = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => {
+    store[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete store[key];
+  },
+  clear: () => {
+    for (const key of Object.keys(store)) {
+      delete store[key];
+    }
+  },
+  get length() {
+    return Object.keys(store).length;
+  },
+  key: (index: number) => Object.keys(store)[index] ?? null,
+};
+
+// Zustand persist accesses window.localStorage, so we need both
+if (typeof window === "undefined") {
+  (globalThis as Record<string, unknown>).window = globalThis;
+}
+Object.defineProperty(globalThis, "localStorage", {
+  value: storageMock,
+  writable: true,
+  configurable: true,
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   base: "/GLORP/",
   test: {
     environment: "node",
+    setupFiles: ["./src/test-setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary

Implement the central Zustand game store that holds all mutable game state and persists it to localStorage. This is the foundation every other feature builds on.

## Changes

| File | Description |
|------|-------------|
| `src/store/gameStore.ts` | Zustand 5 store with `persist` middleware, holds `trainingData`, `totalClicks`, `evolutionStage`, `lastSaved` |
| `src/store/index.ts` | Barrel export for clean import paths |
| `src/store/gameStore.test.ts` | 12 Vitest unit tests covering `clickFeed` and `addTrainingData` actions |
| `src/test-setup.ts` | localStorage mock for Node test environment (Zustand persist uses `window.localStorage`) |
| `vite.config.ts` | Add `setupFiles` config so localStorage mock loads before store imports |

### Store shape

| Field | Type | Description |
|-------|------|-------------|
| `trainingData` | `number` | Main currency, incremented by clicks and passive income |
| `totalClicks` | `number` | Lifetime click counter |
| `evolutionStage` | `number` | Current evolution (0-5) |
| `lastSaved` | `number` | Timestamp of last state change |

### Actions

| Action | Behavior |
|--------|----------|
| `clickFeed()` | Increments `trainingData` +1 and `totalClicks` +1 |
| `addTrainingData(amount)` | Adds amount to `trainingData` (for passive income engine) |

## Story

Closes #3

## Testing

```bash
npm install
npm test        # 28 tests (16 existing + 12 new), all passing
npm run lint    # Biome — no errors
npm run build   # TypeScript + Vite — builds cleanly
```

Tests cover: initial state, single clicks, accumulated clicks, isolation between actions, timestamp updates, fractional amounts, and combined clickFeed + addTrainingData interactions.