### PR TITLE
feat: basic UI layout, ASCII pet display & click mechanic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,5 @@
-import { Container, Text, Title } from "@mantine/core";
+import { GameLayout } from "./components";
 
 export function App() {
-  return (
-    <Container size="sm" py="xl">
-      <Title order={1}>GLORP</Title>
-      <Text c="dimmed" mt="sm">
-        Generalized Learning Organism for Recursive Processing
-      </Text>
-    </Container>
-  );
+  return <GameLayout />;
 }

--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -1,0 +1,25 @@
+import { AppShell, Grid } from "@mantine/core";
+import { PetDisplay } from "./PetDisplay";
+import { StatsBar } from "./StatsBar";
+import { UpgradesPanel } from "./UpgradesPanel";
+
+export function GameLayout() {
+  return (
+    <AppShell header={{ height: 44 }} padding={0}>
+      <AppShell.Header>
+        <StatsBar />
+      </AppShell.Header>
+
+      <AppShell.Main>
+        <Grid gutter={0} style={{ minHeight: "calc(100vh - 44px)" }}>
+          <Grid.Col span={{ base: 12, md: 8 }}>
+            <PetDisplay />
+          </Grid.Col>
+          <Grid.Col span={{ base: 12, md: 4 }}>
+            <UpgradesPanel />
+          </Grid.Col>
+        </Grid>
+      </AppShell.Main>
+    </AppShell>
+  );
+}

--- a/src/components/PetDisplay.tsx
+++ b/src/components/PetDisplay.tsx
@@ -1,0 +1,38 @@
+import { Button, Stack } from "@mantine/core";
+import { ASCII_ART } from "../data/asciiArt";
+import { useGameStore } from "../store";
+
+export function PetDisplay() {
+  const evolutionStage = useGameStore((s) => s.evolutionStage);
+  const clickFeed = useGameStore((s) => s.clickFeed);
+  const art = ASCII_ART[evolutionStage] ?? ASCII_ART[0];
+
+  return (
+    <Stack align="center" justify="center" gap="lg" h="100%">
+      <div
+        role="img"
+        aria-label={`GLORP pet stage ${evolutionStage}`}
+        style={{
+          fontFamily: "monospace",
+          whiteSpace: "pre",
+          fontSize: "1.5rem",
+          lineHeight: 1.4,
+          color: "var(--mantine-color-green-4)",
+          textAlign: "center",
+          userSelect: "none",
+        }}
+      >
+        {art}
+      </div>
+      <Button
+        size="lg"
+        variant="outline"
+        color="green"
+        onClick={clickFeed}
+        style={{ fontFamily: "monospace" }}
+      >
+        [ FEED GLORP ]
+      </Button>
+    </Stack>
+  );
+}

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -1,0 +1,31 @@
+import { Group, Text } from "@mantine/core";
+import { useGameStore } from "../store";
+import { formatNumber } from "../utils/formatNumber";
+
+export function StatsBar() {
+  const trainingData = useGameStore((s) => s.trainingData);
+
+  return (
+    <Group
+      justify="space-between"
+      px="md"
+      py="xs"
+      style={{
+        borderBottom: "1px solid var(--mantine-color-dark-4)",
+      }}
+    >
+      <Text size="sm" ff="monospace">
+        Training Data:{" "}
+        <Text span fw={700} c="green">
+          {formatNumber(trainingData)}
+        </Text>
+      </Text>
+      <Text size="sm" ff="monospace">
+        TD/s:{" "}
+        <Text span fw={700} c="dimmed">
+          0.0
+        </Text>
+      </Text>
+    </Group>
+  );
+}

--- a/src/components/UpgradesPanel.tsx
+++ b/src/components/UpgradesPanel.tsx
@@ -1,0 +1,21 @@
+import { Stack, Text, Title } from "@mantine/core";
+
+export function UpgradesPanel() {
+  return (
+    <Stack
+      gap="sm"
+      p="md"
+      style={{
+        borderLeft: "1px solid var(--mantine-color-dark-4)",
+        height: "100%",
+      }}
+    >
+      <Title order={4} ff="monospace" c="green">
+        Upgrades
+      </Title>
+      <Text size="sm" c="dimmed" ff="monospace">
+        No upgrades available yet.
+      </Text>
+    </Stack>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,4 @@
+export { GameLayout } from "./GameLayout";
+export { PetDisplay } from "./PetDisplay";
+export { StatsBar } from "./StatsBar";
+export { UpgradesPanel } from "./UpgradesPanel";

--- a/src/data/asciiArt.test.ts
+++ b/src/data/asciiArt.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { ASCII_ART } from "./asciiArt";
+
+describe("ASCII_ART", () => {
+  it("contains stage 0 art", () => {
+    expect(ASCII_ART[0]).toBeDefined();
+  });
+
+  it("stage 0 art is a multi-line string", () => {
+    const lines = ASCII_ART[0].split("\n");
+    expect(lines.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("stage 0 art contains GLORP", () => {
+    expect(ASCII_ART[0]).toContain("GLORP");
+  });
+
+  it("stage 0 art is a string value", () => {
+    expect(typeof ASCII_ART[0]).toBe("string");
+  });
+});

--- a/src/data/asciiArt.ts
+++ b/src/data/asciiArt.ts
@@ -1,0 +1,10 @@
+export const ASCII_ART: Record<number, string> = {
+  0: [
+    "  .-~~~-.",
+    " /       \\",
+    "|  O   O  |",
+    "|    ~    |",
+    " \\_____/",
+    "   GLORP",
+  ].join("\n"),
+};

--- a/src/global.css
+++ b/src/global.css
@@ -1,0 +1,14 @@
+:root {
+  --neon-green: #39ff14;
+}
+
+body {
+  margin: 0;
+  background-color: #0a0a0a;
+  color: #c0c0c0;
+}
+
+::selection {
+  background-color: rgba(57, 255, 20, 0.3);
+  color: #fff;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import "@mantine/core/styles.css";
+import "./global.css";
 
 import { createTheme, MantineProvider } from "@mantine/core";
 import { StrictMode } from "react";


### PR DESCRIPTION
## Summary
Build the initial three-panel game UI with pet display, stats bar, and upgrades column. Wire up the click interaction so players can earn Training Data.

Closes #4

## Changes
- **GameLayout** (`src/components/GameLayout.tsx`): Three-panel layout using Mantine `AppShell` + `Grid` — top stats bar, left/center pet area, right upgrades panel
- **StatsBar** (`src/components/StatsBar.tsx`): Displays current Training Data count (formatted via `formatNumber`) and TD/s (0.0 placeholder)
- **PetDisplay** (`src/components/PetDisplay.tsx`): ASCII Blob (Stage 0) art in a monospace container with a "FEED GLORP" button wired to `clickFeed()`
- **UpgradesPanel** (`src/components/UpgradesPanel.tsx`): Placeholder panel for future upgrade cards
- **ASCII art data** (`src/data/asciiArt.ts`): Stage 0 Blob art (6-line ASCII) keyed by evolution stage
- **App.tsx**: Updated to render the new `GameLayout`
- **main.tsx + global.css**: Added neon terminal aesthetics (dark background, green accent, monospace fonts)
- **Tests**: 4 new tests for ASCII art data structure (32 total, all passing)

## Story
[[Phase 1] Basic UI layout, ASCII pet display & click mechanic](https://github.com/AshDevFr/GLORP/issues/4)

## Acceptance Criteria Status
- [x] App renders a three-panel layout: left/center pet display, right upgrades panel, top stats bar
- [x] Stats bar shows current Training Data count (formatted via `formatNumber`) and TD/s (0.0 at this stage)
- [x] ASCII pet area displays a static Blob (Stage 0) art inside a monospace container (not a Mantine component)
- [x] Clicking the pet/feed button calls `clickFeed()` and the stats bar updates immediately
- [x] Layout is responsive: looks reasonable on screens >= 1024px wide
- [x] Dark theme with neon terminal aesthetics applied (monospace font, dark background, neon accent colour)
- [x] `npm run build` succeeds

## Testing
1. `npm test` — 32 tests pass (including 4 new ASCII art tests)
2. `npx biome check .` — lint clean
3. `npm run build` — builds successfully
4. Open the app in a browser to verify the three-panel layout, click the FEED GLORP button, and confirm the Training Data counter increments