### PR TITLE
feat: upgrade data definitions, cost scaling & purchase logic

### DIFF
--- a/src/data/upgrades.test.ts
+++ b/src/data/upgrades.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { UPGRADES } from "./upgrades";
+
+describe("UPGRADES", () => {
+  it("contains at least 6 upgrades", () => {
+    expect(UPGRADES.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("has unique ids", () => {
+    const ids = UPGRADES.map((u) => u.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("includes both garage-lab and startup tiers", () => {
+    const tiers = new Set(UPGRADES.map((u) => u.tier));
+    expect(tiers.has("garage-lab")).toBe(true);
+    expect(tiers.has("startup")).toBe(true);
+  });
+
+  it("each upgrade has required fields", () => {
+    for (const u of UPGRADES) {
+      expect(u.id).toBeTruthy();
+      expect(u.name).toBeTruthy();
+      expect(u.description).toBeTruthy();
+      expect(u.baseCost).toBeGreaterThan(0);
+      expect(u.baseTdPerSecond).toBeGreaterThan(0);
+      expect(u.icon).toBeTruthy();
+    }
+  });
+
+  it("garage-lab upgrades cost between 10 and 500", () => {
+    const garageLab = UPGRADES.filter((u) => u.tier === "garage-lab");
+    expect(garageLab.length).toBeGreaterThanOrEqual(3);
+    for (const u of garageLab) {
+      expect(u.baseCost).toBeGreaterThanOrEqual(10);
+      expect(u.baseCost).toBeLessThanOrEqual(500);
+    }
+  });
+
+  it("startup upgrades cost between 1K and 50K", () => {
+    const startup = UPGRADES.filter((u) => u.tier === "startup");
+    expect(startup.length).toBeGreaterThanOrEqual(3);
+    for (const u of startup) {
+      expect(u.baseCost).toBeGreaterThanOrEqual(1_000);
+      expect(u.baseCost).toBeLessThanOrEqual(50_000);
+    }
+  });
+});

--- a/src/data/upgrades.ts
+++ b/src/data/upgrades.ts
@@ -1,0 +1,67 @@
+export interface Upgrade {
+  id: string;
+  name: string;
+  description: string;
+  baseCost: number;
+  baseTdPerSecond: number;
+  tier: "garage-lab" | "startup";
+  icon: string;
+}
+
+export const UPGRADES: readonly Upgrade[] = [
+  {
+    id: "neural-notepad",
+    name: "Neural Notepad",
+    description: "A simple notepad that jots down patterns while you sleep.",
+    baseCost: 10,
+    baseTdPerSecond: 0.1,
+    tier: "garage-lab",
+    icon: "📝",
+  },
+  {
+    id: "data-hamster-wheel",
+    name: "Data Hamster Wheel",
+    description: "A tiny hamster processes data one byte at a time.",
+    baseCost: 50,
+    baseTdPerSecond: 0.5,
+    tier: "garage-lab",
+    icon: "🐹",
+  },
+  {
+    id: "pattern-antenna",
+    name: "Pattern Antenna",
+    description: "Picks up stray patterns from the airwaves.",
+    baseCost: 250,
+    baseTdPerSecond: 2,
+    tier: "garage-lab",
+    icon: "📡",
+  },
+  {
+    id: "intern-algorithm",
+    name: "Intern Algorithm",
+    description: "An unpaid algorithm that sorts data surprisingly well.",
+    baseCost: 1_000,
+    baseTdPerSecond: 5,
+    tier: "startup",
+    icon: "🧑‍💻",
+  },
+  {
+    id: "cloud-crumb",
+    name: "Cloud Crumb",
+    description:
+      "A tiny slice of cloud compute, barely enough for a breadcrumb.",
+    baseCost: 5_000,
+    baseTdPerSecond: 20,
+    tier: "startup",
+    icon: "☁️",
+  },
+  {
+    id: "gpu-toaster",
+    name: "GPU Toaster",
+    description: "Repurposed toaster with a graphics card duct-taped inside.",
+    baseCost: 25_000,
+    baseTdPerSecond: 100,
+    tier: "startup",
+    icon: "🍞",
+  },
+];

--- a/src/engine/upgradeEngine.test.ts
+++ b/src/engine/upgradeEngine.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { Upgrade } from "../data/upgrades";
+import { getTotalTdPerSecond, getUpgradeCost } from "./upgradeEngine";
+
+const mockUpgrade: Upgrade = {
+  id: "test-upgrade",
+  name: "Test Upgrade",
+  description: "A test upgrade",
+  baseCost: 100,
+  baseTdPerSecond: 1.5,
+  tier: "garage-lab",
+  icon: "🧪",
+};
+
+const mockUpgrade2: Upgrade = {
+  id: "test-upgrade-2",
+  name: "Test Upgrade 2",
+  description: "Another test upgrade",
+  baseCost: 500,
+  baseTdPerSecond: 5,
+  tier: "startup",
+  icon: "🔬",
+};
+
+describe("getUpgradeCost", () => {
+  it("returns baseCost when owned is 0", () => {
+    expect(getUpgradeCost(mockUpgrade, 0)).toBe(100);
+  });
+
+  it("scales cost by 1.15 for each owned", () => {
+    expect(getUpgradeCost(mockUpgrade, 1)).toBe(Math.floor(100 * 1.15));
+  });
+
+  it("scales exponentially for multiple owned", () => {
+    expect(getUpgradeCost(mockUpgrade, 5)).toBe(Math.floor(100 * 1.15 ** 5));
+  });
+
+  it("scales correctly for 10 owned", () => {
+    expect(getUpgradeCost(mockUpgrade, 10)).toBe(Math.floor(100 * 1.15 ** 10));
+  });
+
+  it("floors the result to an integer", () => {
+    const cost = getUpgradeCost(mockUpgrade, 1);
+    expect(Number.isInteger(cost)).toBe(true);
+  });
+
+  it("works with different base costs", () => {
+    expect(getUpgradeCost(mockUpgrade2, 0)).toBe(500);
+    expect(getUpgradeCost(mockUpgrade2, 3)).toBe(Math.floor(500 * 1.15 ** 3));
+  });
+});
+
+describe("getTotalTdPerSecond", () => {
+  it("returns 0 when no upgrades are owned", () => {
+    expect(getTotalTdPerSecond([mockUpgrade, mockUpgrade2], {})).toBe(0);
+  });
+
+  it("returns correct TD/s for a single owned upgrade", () => {
+    const owned = { "test-upgrade": 3 };
+    expect(getTotalTdPerSecond([mockUpgrade], owned)).toBeCloseTo(4.5);
+  });
+
+  it("sums TD/s across multiple upgrade types", () => {
+    const owned = { "test-upgrade": 2, "test-upgrade-2": 1 };
+    expect(getTotalTdPerSecond([mockUpgrade, mockUpgrade2], owned)).toBeCloseTo(
+      8,
+    );
+  });
+
+  it("ignores upgrades not in the owned map", () => {
+    const owned = { "test-upgrade": 1 };
+    expect(getTotalTdPerSecond([mockUpgrade, mockUpgrade2], owned)).toBeCloseTo(
+      1.5,
+    );
+  });
+
+  it("handles empty upgrades array", () => {
+    expect(getTotalTdPerSecond([], { "test-upgrade": 5 })).toBe(0);
+  });
+});

--- a/src/engine/upgradeEngine.ts
+++ b/src/engine/upgradeEngine.ts
@@ -1,0 +1,19 @@
+import type { Upgrade } from "../data/upgrades";
+
+const COST_MULTIPLIER = 1.15;
+
+export function getUpgradeCost(upgrade: Upgrade, owned: number): number {
+  return Math.floor(upgrade.baseCost * COST_MULTIPLIER ** owned);
+}
+
+export function getTotalTdPerSecond(
+  upgrades: readonly Upgrade[],
+  owned: Record<string, number>,
+): number {
+  let total = 0;
+  for (const upgrade of upgrades) {
+    const count = owned[upgrade.id] ?? 0;
+    total += upgrade.baseTdPerSecond * count;
+  }
+  return total;
+}

--- a/src/store/gameStore.test.ts
+++ b/src/store/gameStore.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UPGRADES } from "../data/upgrades";
+import { getUpgradeCost } from "../engine/upgradeEngine";
 import { initialGameState, useGameStore } from "./gameStore";
 
 beforeEach(() => {
@@ -18,6 +20,11 @@ describe("gameStore", () => {
       expect(state.totalClicks).toBe(0);
       expect(state.evolutionStage).toBe(0);
       expect(state.lastSaved).toBe(0);
+    });
+
+    it("has empty upgradeOwned", () => {
+      const state = useGameStore.getState();
+      expect(state.upgradeOwned).toEqual({});
     });
   });
 
@@ -95,6 +102,67 @@ describe("gameStore", () => {
       const state = useGameStore.getState();
       expect(state.trainingData).toBe(102);
       expect(state.totalClicks).toBe(2);
+    });
+  });
+
+  describe("purchaseUpgrade", () => {
+    const firstUpgrade = UPGRADES[0];
+    const baseCost = firstUpgrade.baseCost;
+
+    it("deducts cost and increments owned count", () => {
+      useGameStore.setState({ trainingData: baseCost });
+      useGameStore.getState().purchaseUpgrade(firstUpgrade.id);
+      const state = useGameStore.getState();
+      expect(state.trainingData).toBe(0);
+      expect(state.upgradeOwned[firstUpgrade.id]).toBe(1);
+    });
+
+    it("no-ops when player cannot afford", () => {
+      useGameStore.setState({ trainingData: baseCost - 1 });
+      useGameStore.getState().purchaseUpgrade(firstUpgrade.id);
+      const state = useGameStore.getState();
+      expect(state.trainingData).toBe(baseCost - 1);
+      expect(state.upgradeOwned[firstUpgrade.id]).toBeUndefined();
+    });
+
+    it("scales cost after purchase", () => {
+      const totalNeeded = baseCost + getUpgradeCost(firstUpgrade, 1);
+      useGameStore.setState({ trainingData: totalNeeded });
+      useGameStore.getState().purchaseUpgrade(firstUpgrade.id);
+      useGameStore.getState().purchaseUpgrade(firstUpgrade.id);
+      const state = useGameStore.getState();
+      expect(state.upgradeOwned[firstUpgrade.id]).toBe(2);
+      expect(state.trainingData).toBe(0);
+    });
+
+    it("no-ops for unknown upgrade id", () => {
+      useGameStore.setState({ trainingData: 999_999 });
+      useGameStore.getState().purchaseUpgrade("nonexistent");
+      const state = useGameStore.getState();
+      expect(state.trainingData).toBe(999_999);
+    });
+
+    it("updates lastSaved on purchase", () => {
+      useGameStore.setState({ trainingData: baseCost });
+      const before = Date.now();
+      useGameStore.getState().purchaseUpgrade(firstUpgrade.id);
+      const after = Date.now();
+      const { lastSaved } = useGameStore.getState();
+      expect(lastSaved).toBeGreaterThanOrEqual(before);
+      expect(lastSaved).toBeLessThanOrEqual(after);
+    });
+
+    it("allows purchasing different upgrades independently", () => {
+      const secondUpgrade = UPGRADES[1];
+      useGameStore.setState({
+        trainingData: firstUpgrade.baseCost + secondUpgrade.baseCost,
+      });
+      useGameStore.getState().purchaseUpgrade(firstUpgrade.id);
+      useGameStore.getState().purchaseUpgrade(secondUpgrade.id);
+      const state = useGameStore.getState();
+      expect(state.upgradeOwned[firstUpgrade.id]).toBe(1);
+      expect(state.upgradeOwned[secondUpgrade.id]).toBe(1);
+      expect(state.trainingData).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
Define the first two upgrade tiers (Garage Lab & Startup) as static data and implement purchase logic so players can spend Training Data to unlock passive income sources.

Closes #5

## Changes
- **Upgrade data** (`src/data/upgrades.ts`): 6 upgrades across Garage Lab (10–250 TD) and Startup (1K–25K TD) tiers, each with `id`, `name`, `description`, `baseCost`, `baseTdPerSecond`, `tier`, `icon`
- **Engine functions** (`src/engine/upgradeEngine.ts`): Pure functions `getUpgradeCost(upgrade, owned)` using `baseCost * 1.15^owned` formula and `getTotalTdPerSecond(upgrades, owned)` for aggregation
- **Store extension** (`src/store/gameStore.ts`): Added `upgradeOwned: Record<string, number>` to state and `purchaseUpgrade(id)` action that deducts cost and increments owned count (no-ops if unaffordable)
- **Tests**: 24 new tests (6 upgrade data + 11 engine + 7 store purchase) — 56 total passing

## Upgrade Tiers

### Garage Lab (10–250 TD)
| Upgrade | Base Cost | TD/s | Icon |
|---------|-----------|------|------|
| Neural Notepad | 10 | 0.1 | 📝 |
| Data Hamster Wheel | 50 | 0.5 | 🐹 |
| Pattern Antenna | 250 | 2.0 | 📡 |

### Startup (1K–25K TD)
| Upgrade | Base Cost | TD/s | Icon |
|---------|-----------|------|------|
| Intern Algorithm | 1,000 | 5 | 🧑‍💻 |
| Cloud Crumb | 5,000 | 20 | ☁️ |
| GPU Toaster | 25,000 | 100 | 🍞 |

## Story
[[Phase 2] Upgrade data definitions, cost scaling & purchase logic](https://github.com/AshDevFr/GLORP/issues/5)

## Testing
1. `npm test` — 56 tests pass (5 test files)
2. `npx biome check .` — lint clean
3. `npm run build` — builds successfully