### PR TITLE
feat: passive income engine & game tick loop

### DIFF
--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -1,9 +1,12 @@
 import { AppShell, Grid } from "@mantine/core";
+import { useGameLoop } from "../hooks/useGameLoop";
 import { PetDisplay } from "./PetDisplay";
 import { StatsBar } from "./StatsBar";
 import { UpgradesPanel } from "./UpgradesPanel";
 
 export function GameLayout() {
+  useGameLoop();
+
   return (
     <AppShell header={{ height: 44 }} padding={0}>
       <AppShell.Header>

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -1,9 +1,13 @@
 import { Group, Text } from "@mantine/core";
+import { UPGRADES } from "../data/upgrades";
+import { getTotalTdPerSecond } from "../engine/upgradeEngine";
 import { useGameStore } from "../store";
 import { formatNumber } from "../utils/formatNumber";
 
 export function StatsBar() {
   const trainingData = useGameStore((s) => s.trainingData);
+  const upgradeOwned = useGameStore((s) => s.upgradeOwned);
+  const tdPerSecond = getTotalTdPerSecond(UPGRADES, upgradeOwned);
 
   return (
     <Group
@@ -22,8 +26,8 @@ export function StatsBar() {
       </Text>
       <Text size="sm" ff="monospace">
         TD/s:{" "}
-        <Text span fw={700} c="dimmed">
-          0.0
+        <Text span fw={700} c={tdPerSecond > 0 ? "green" : "dimmed"}>
+          {tdPerSecond > 0 ? formatNumber(tdPerSecond) : "0.0"}
         </Text>
       </Text>
     </Group>

--- a/src/engine/tickEngine.test.ts
+++ b/src/engine/tickEngine.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { computeTick } from "./tickEngine";
+
+describe("computeTick", () => {
+  it("returns zero delta when no upgrades are owned", () => {
+    const result = computeTick({ upgradeOwned: {} }, 1);
+    expect(result.trainingDataDelta).toBe(0);
+  });
+
+  it("returns zero delta when deltaSeconds is 0", () => {
+    const result = computeTick({ upgradeOwned: { "neural-notepad": 5 } }, 0);
+    expect(result.trainingDataDelta).toBe(0);
+  });
+
+  it("computes correct delta for one upgrade owned", () => {
+    // neural-notepad: baseTdPerSecond = 0.1, 1 owned => 0.1 TD/s
+    const result = computeTick({ upgradeOwned: { "neural-notepad": 1 } }, 1);
+    expect(result.trainingDataDelta).toBeCloseTo(0.1);
+  });
+
+  it("scales with number of upgrades owned", () => {
+    // neural-notepad: 0.1 * 3 = 0.3 TD/s
+    const result = computeTick({ upgradeOwned: { "neural-notepad": 3 } }, 1);
+    expect(result.trainingDataDelta).toBeCloseTo(0.3);
+  });
+
+  it("sums across multiple upgrade types", () => {
+    // neural-notepad: 0.1 * 2 = 0.2, data-hamster-wheel: 0.5 * 1 = 0.5 => 0.7
+    const result = computeTick(
+      {
+        upgradeOwned: {
+          "neural-notepad": 2,
+          "data-hamster-wheel": 1,
+        },
+      },
+      1,
+    );
+    expect(result.trainingDataDelta).toBeCloseTo(0.7);
+  });
+
+  it("scales with delta time", () => {
+    // neural-notepad: 0.1 * 1 = 0.1 TD/s, delta = 2.5s => 0.25
+    const result = computeTick({ upgradeOwned: { "neural-notepad": 1 } }, 2.5);
+    expect(result.trainingDataDelta).toBeCloseTo(0.25);
+  });
+
+  it("handles fractional delta seconds", () => {
+    // gpu-toaster: 100 * 1 = 100 TD/s, delta = 0.016s => 1.6
+    const result = computeTick({ upgradeOwned: { "gpu-toaster": 1 } }, 0.016);
+    expect(result.trainingDataDelta).toBeCloseTo(1.6);
+  });
+
+  it("handles all upgrade types combined", () => {
+    // All 6 upgrades, 1 each:
+    // 0.1 + 0.5 + 2 + 5 + 20 + 100 = 127.6 TD/s
+    const result = computeTick(
+      {
+        upgradeOwned: {
+          "neural-notepad": 1,
+          "data-hamster-wheel": 1,
+          "pattern-antenna": 1,
+          "intern-algorithm": 1,
+          "cloud-crumb": 1,
+          "gpu-toaster": 1,
+        },
+      },
+      1,
+    );
+    expect(result.trainingDataDelta).toBeCloseTo(127.6);
+  });
+});

--- a/src/engine/tickEngine.ts
+++ b/src/engine/tickEngine.ts
@@ -1,0 +1,20 @@
+import { UPGRADES } from "../data/upgrades";
+import { getTotalTdPerSecond } from "./upgradeEngine";
+
+interface TickState {
+  upgradeOwned: Record<string, number>;
+}
+
+interface TickResult {
+  trainingDataDelta: number;
+}
+
+export function computeTick(
+  state: TickState,
+  deltaSeconds: number,
+): TickResult {
+  const tdPerSecond = getTotalTdPerSecond(UPGRADES, state.upgradeOwned);
+  return {
+    trainingDataDelta: tdPerSecond * deltaSeconds,
+  };
+}

--- a/src/hooks/useGameLoop.ts
+++ b/src/hooks/useGameLoop.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from "react";
+import { computeTick } from "../engine/tickEngine";
+import { useGameStore } from "../store";
+
+const TICK_INTERVAL_MS = 1000;
+
+export function useGameLoop() {
+  const lastTickRef = useRef(Date.now());
+
+  useEffect(() => {
+    lastTickRef.current = Date.now();
+
+    const id = setInterval(() => {
+      const now = Date.now();
+      const deltaSeconds = (now - lastTickRef.current) / 1000;
+      lastTickRef.current = now;
+
+      const state = useGameStore.getState();
+      const result = computeTick(state, deltaSeconds);
+
+      if (result.trainingDataDelta > 0) {
+        state.addTrainingData(result.trainingDataDelta);
+      }
+    }, TICK_INTERVAL_MS);
+
+    return () => clearInterval(id);
+  }, []);
+}


### PR DESCRIPTION
## Summary
Implement a recurring game tick that computes total TD/s from owned upgrades and automatically adds Training Data every second, turning GLORP into a true idle game.

Closes #6

## Changes
- **Tick engine** (`src/engine/tickEngine.ts`): Pure `computeTick(state, deltaSeconds)` function that calculates training data delta from owned upgrades' total TD/s multiplied by elapsed seconds
- **Game loop hook** (`src/hooks/useGameLoop.ts`): `useGameLoop()` hook using `setInterval` at 1s resolution with actual delta time measurement (not fixed 1000ms assumption) and clean unmount via `clearInterval`
- **GameLayout** (`src/components/GameLayout.tsx`): Wired `useGameLoop()` into the top-level layout component
- **StatsBar** (`src/components/StatsBar.tsx`): Now displays live TD/s value computed from `getTotalTdPerSecond(UPGRADES, upgradeOwned)`, updates whenever upgrades are purchased
- **Tests**: 8 new tests for `computeTick` covering zero upgrades, single upgrade, multiple upgrades, delta time scaling, fractional deltas, and all upgrade types combined

## Acceptance Criteria Status
- [x] `src/engine/tickEngine.ts` exports `computeTick(state, deltaSeconds)` as a pure function
- [x] Tick applies TD/s total multiplied by elapsed seconds
- [x] React hook starts `setInterval` at 1s and calls `addTrainingData` with tick result
- [x] Stats bar displays live TD/s value (updates on upgrade purchase)
- [x] Tick stops cleanly on unmount (clearInterval in useEffect cleanup)
- [x] Vitest tests cover computeTick with zero, one, and multiple upgrades owned

## Story
[[Phase 2] Passive income engine & game tick loop](https://github.com/AshDevFr/GLORP/issues/6)

## Testing
1. `npm test` — 64 tests pass (6 test files)
2. `npx biome check .` — lint clean
3. `npm run build` — builds successfully
4. Open app, purchase upgrades, verify TD/s displays and training data auto-increments