### PR TITLE
feat: Upgrade cards UI (Garage Lab & Startup tiers)

### DIFF
--- a/src/components/UpgradesPanel.tsx
+++ b/src/components/UpgradesPanel.tsx
@@ -1,6 +1,20 @@
-import { Stack, Text, Title } from "@mantine/core";
+import { ScrollArea, Stack, Text, Title } from "@mantine/core";
+import { UPGRADES } from "../data/upgrades";
+import { useGameStore } from "../store";
+import { UpgradeCard } from "./upgrades/UpgradeCard";
+
+const GARAGE_LAB_UPGRADES = UPGRADES.filter((u) => u.tier === "garage-lab");
+const STARTUP_UPGRADES = UPGRADES.filter((u) => u.tier === "startup");
 
 export function UpgradesPanel() {
+  const trainingData = useGameStore((s) => s.trainingData);
+  const upgradeOwned = useGameStore((s) => s.upgradeOwned);
+  const purchaseUpgrade = useGameStore((s) => s.purchaseUpgrade);
+
+  const hasGarageLabUpgrade = GARAGE_LAB_UPGRADES.some(
+    (u) => (upgradeOwned[u.id] ?? 0) > 0,
+  );
+
   return (
     <Stack
       gap="sm"
@@ -8,14 +22,45 @@ export function UpgradesPanel() {
       style={{
         borderLeft: "1px solid var(--mantine-color-dark-4)",
         height: "100%",
+        overflow: "hidden",
       }}
     >
       <Title order={4} ff="monospace" c="green">
         Upgrades
       </Title>
-      <Text size="sm" c="dimmed" ff="monospace">
-        No upgrades available yet.
-      </Text>
+      <ScrollArea style={{ flex: 1 }}>
+        <Stack gap="xs">
+          <Text size="xs" fw={700} ff="monospace" c="dimmed">
+            🔬 Garage Lab
+          </Text>
+          {GARAGE_LAB_UPGRADES.map((upgrade) => (
+            <UpgradeCard
+              key={upgrade.id}
+              upgrade={upgrade}
+              owned={upgradeOwned[upgrade.id] ?? 0}
+              trainingData={trainingData}
+              onPurchase={purchaseUpgrade}
+            />
+          ))}
+
+          {hasGarageLabUpgrade && (
+            <>
+              <Text size="xs" fw={700} ff="monospace" c="dimmed" mt="sm">
+                🚀 Startup
+              </Text>
+              {STARTUP_UPGRADES.map((upgrade) => (
+                <UpgradeCard
+                  key={upgrade.id}
+                  upgrade={upgrade}
+                  owned={upgradeOwned[upgrade.id] ?? 0}
+                  trainingData={trainingData}
+                  onPurchase={purchaseUpgrade}
+                />
+              ))}
+            </>
+          )}
+        </Stack>
+      </ScrollArea>
     </Stack>
   );
 }

--- a/src/components/upgrades/UpgradeCard.tsx
+++ b/src/components/upgrades/UpgradeCard.tsx
@@ -1,0 +1,64 @@
+import { Badge, Button, Card, Group, Text } from "@mantine/core";
+import type { Upgrade } from "../../data/upgrades";
+import { getUpgradeCost } from "../../engine/upgradeEngine";
+import { formatNumber } from "../../utils/formatNumber";
+
+interface UpgradeCardProps {
+  upgrade: Upgrade;
+  owned: number;
+  trainingData: number;
+  onPurchase: (id: string) => void;
+}
+
+export function UpgradeCard({
+  upgrade,
+  owned,
+  trainingData,
+  onPurchase,
+}: UpgradeCardProps) {
+  const cost = getUpgradeCost(upgrade, owned);
+  const canAfford = trainingData >= cost;
+
+  return (
+    <Card
+      padding="sm"
+      radius="sm"
+      withBorder
+      style={{
+        borderColor: canAfford
+          ? "var(--mantine-color-green-8)"
+          : "var(--mantine-color-dark-4)",
+        opacity: canAfford ? 1 : 0.5,
+      }}
+    >
+      <Group justify="space-between" mb={4}>
+        <Text size="sm" fw={700} ff="monospace">
+          {upgrade.icon} {upgrade.name}
+        </Text>
+        <Badge size="sm" variant="light" color="green">
+          x{owned}
+        </Badge>
+      </Group>
+
+      <Text size="xs" c="dimmed" ff="monospace" mb="xs">
+        {upgrade.description}
+      </Text>
+
+      <Group justify="space-between" align="center">
+        <Text size="xs" ff="monospace" c="green">
+          +{formatNumber(upgrade.baseTdPerSecond)} TD/s
+        </Text>
+        <Button
+          size="compact-xs"
+          variant={canAfford ? "filled" : "default"}
+          color="green"
+          disabled={!canAfford}
+          onClick={() => onPurchase(upgrade.id)}
+          ff="monospace"
+        >
+          {formatNumber(cost)} TD
+        </Button>
+      </Group>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary\nReplace the placeholder UpgradesPanel with interactive upgrade cards grouped by tier. Each card shows name, description, cost, TD/s bonus, and owned count. Unaffordable upgrades are visually dimmed with a disabled button. The Startup tier unlocks after purchasing at least one Garage Lab upgrade.\n\nCloses #8\n\n## Changes\n- **`src/components/upgrades/UpgradeCard.tsx`** — New small component rendering a single Mantine Card with upgrade info, affordability styling (green border + full opacity when affordable, dark border + 50% opacity when not), and a purchase button\n- **`src/components/UpgradesPanel.tsx`** — Rewrote from placeholder to render all upgrades grouped by tier inside a Mantine ScrollArea for overflow scrolling. Garage Lab tier is always visible; Startup tier appears only when the player owns at least one Garage Lab upgrade\n\n## Story\n[Phase 2: Upgrade cards UI (Garage Lab & Startup tiers)](https://github.com/AshDevFr/GLORP/issues/8)\n\n## Testing\n- 84 existing tests pass (no regressions)\n- Lint (Biome), TypeScript, and production build all clean\n- Manual verification: Garage Lab cards render with cost/TD-s/owned count. Buying an upgrade updates cost immediately and TD/s in stats bar. Startup tier hidden until first Garage Lab purchase. Unaffordable cards dimmed with disabled button. Panel scrolls on overflow.</n"