### PR TITLE
fix: Display fractional TD/s values on upgrade cards

### DIFF
--- a/src/utils/formatNumber.test.ts
+++ b/src/utils/formatNumber.test.ts
@@ -13,9 +13,16 @@ describe("formatNumber", () => {
       expect(formatNumber(999)).toBe("999");
     });
 
-    it("truncates decimals to integer", () => {
+    it("truncates decimals >= 1 to integer", () => {
       expect(formatNumber(1.9)).toBe("1");
       expect(formatNumber(999.99)).toBe("999");
+    });
+
+    it("formats fractional values between 0 and 1 with 2 decimal places", () => {
+      expect(formatNumber(0.1)).toBe("0.10");
+      expect(formatNumber(0.5)).toBe("0.50");
+      expect(formatNumber(0.75)).toBe("0.75");
+      expect(formatNumber(0.01)).toBe("0.01");
     });
   });
 

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -22,5 +22,9 @@ export function formatNumber(n: number): string {
     }
   }
 
+  if (n > 0 && n < 1) {
+    return n.toFixed(2);
+  }
+
   return Math.floor(n).toString();
 }


### PR DESCRIPTION
## Summary\nFix upgrade cards showing \"+0 TD/s\" for upgrades with fractional passive income (Neural Notepad 0.1, Data Hamster Wheel 0.5). Values between 0 and 1 are now formatted with 2 decimal places.\n\nFixes #26\n\n## Changes\n- **`src/utils/formatNumber.ts`** — Added a fractional branch: values where `0 < n < 1` now return `n.toFixed(2)` (e.g. `0.10`, `0.50`) instead of being floored to `0`.\n- **`src/utils/formatNumber.test.ts`** — Added test cases for `0.1`, `0.5`, `0.75`, and `0.01`.\n\n## Story\n[Bug: Upgrade cards show +0 TD/s for fractional values](https://github.com/AshDevFr/GLORP/issues/26)\n\n## Testing\n- 102 tests pass (1 new test case with 4 assertions)\n- Neural Notepad now shows `+0.10 TD/s`, Data Hamster Wheel shows `+0.50 TD/s`\n- Integer values and large numbers unaffected (existing tests pass)"