### PR TITLE
feat: mood mechanic with 6 states, decay & dialogue integration

### DIFF
--- a/src/components/PetDisplay.tsx
+++ b/src/components/PetDisplay.tsx
@@ -2,13 +2,25 @@ import { Button, Stack, Text } from "@mantine/core";
 import { useEffect, useRef, useState } from "react";
 import { ASCII_ART } from "../data/asciiArt";
 import { STAGES } from "../data/stages";
+import { getClickMood } from "../engine/moodEngine";
 import { useDialogue } from "../hooks/useDialogue";
 import { useGameStore } from "../store";
 import { SpeechBubble } from "./SpeechBubble";
 
+const MOOD_LABELS: Record<string, string> = {
+  Happy: ":)",
+  Neutral: ":|",
+  Hungry: ":(",
+  Sad: ":'(",
+  Excited: ":D",
+  Philosophical: "...",
+};
+
 export function PetDisplay() {
   const evolutionStage = useGameStore((s) => s.evolutionStage);
   const clickFeed = useGameStore((s) => s.clickFeed);
+  const mood = useGameStore((s) => s.mood);
+  const setMood = useGameStore((s) => s.setMood);
   const art = ASCII_ART[evolutionStage] ?? ASCII_ART[0];
   const stageMeta = STAGES[evolutionStage] ?? STAGES[0];
 
@@ -25,15 +37,23 @@ export function PetDisplay() {
     }
   }, [evolutionStage]);
 
+  const handlePetClick = () => {
+    setMood(getClickMood());
+  };
+
   return (
     <Stack align="center" justify="center" gap="lg" h="100%">
       <SpeechBubble text={dialogueLine} />
       <Text size="xs" ff="monospace" c="dimmed">
-        Stage {evolutionStage}: {stageMeta.name}
+        Stage {evolutionStage}: {stageMeta.name} [{MOOD_LABELS[mood] ?? mood}]
       </Text>
       <div
         role="img"
         aria-label={`GLORP pet stage ${evolutionStage}: ${stageMeta.name}`}
+        onClick={handlePetClick}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") handlePetClick();
+        }}
         style={{
           fontFamily: "monospace",
           whiteSpace: "pre",
@@ -42,6 +62,7 @@ export function PetDisplay() {
           color: isFlashing ? "#fff" : "var(--mantine-color-green-4)",
           textAlign: "center",
           userSelect: "none",
+          cursor: "pointer",
           textShadow: isFlashing
             ? "0 0 20px #39ff14, 0 0 40px #39ff14"
             : "none",

--- a/src/data/dialogue.test.ts
+++ b/src/data/dialogue.test.ts
@@ -21,20 +21,64 @@ describe("dialogue data", () => {
     }
   });
 
-  it("all idle lines are non-empty strings", () => {
+  it("all idle lines have non-empty text strings", () => {
     for (const stage of [0, 1, 2]) {
       for (const line of DIALOGUE[stage].idle) {
-        expect(typeof line).toBe("string");
-        expect(line.length).toBeGreaterThan(0);
+        expect(typeof line.text).toBe("string");
+        expect(line.text.length).toBeGreaterThan(0);
       }
     }
   });
 
-  it("has no duplicate idle lines within a stage", () => {
+  it("has no duplicate idle texts within a stage", () => {
     for (const stage of [0, 1, 2]) {
-      const lines = DIALOGUE[stage].idle;
-      const unique = new Set(lines);
-      expect(unique.size).toBe(lines.length);
+      const texts = DIALOGUE[stage].idle.map((l) => l.text);
+      const unique = new Set(texts);
+      expect(unique.size).toBe(texts.length);
+    }
+  });
+
+  it("mood tags are valid Mood values when present", () => {
+    const validMoods = [
+      "Happy",
+      "Neutral",
+      "Hungry",
+      "Sad",
+      "Excited",
+      "Philosophical",
+    ];
+    for (const stage of [0, 1, 2]) {
+      for (const line of DIALOGUE[stage].idle) {
+        if (line.moods) {
+          for (const mood of line.moods) {
+            expect(validMoods).toContain(mood);
+          }
+        }
+      }
+    }
+  });
+
+  it("has mood-tagged lines for Happy, Excited, Hungry, and Sad per stage", () => {
+    for (const stage of [0, 1, 2]) {
+      const moodsPresent = new Set<string>();
+      for (const line of DIALOGUE[stage].idle) {
+        if (line.moods) {
+          for (const m of line.moods) {
+            moodsPresent.add(m);
+          }
+        }
+      }
+      expect(moodsPresent.has("Happy")).toBe(true);
+      expect(moodsPresent.has("Excited")).toBe(true);
+      expect(moodsPresent.has("Hungry")).toBe(true);
+      expect(moodsPresent.has("Sad")).toBe(true);
+    }
+  });
+
+  it("has untagged lines (available to any mood) per stage", () => {
+    for (const stage of [0, 1, 2]) {
+      const untagged = DIALOGUE[stage].idle.filter((l) => !l.moods);
+      expect(untagged.length).toBeGreaterThanOrEqual(1);
     }
   });
 });

--- a/src/data/dialogue.ts
+++ b/src/data/dialogue.ts
@@ -1,5 +1,12 @@
+import type { Mood } from "../engine/moodEngine";
+
+export interface DialogueLine {
+  text: string;
+  moods?: Mood[];
+}
+
 export interface DialogueSet {
-  idle: readonly string[];
+  idle: readonly DialogueLine[];
   triggers: {
     firstEvolution: string;
     firstUpgrade: string;
@@ -9,11 +16,18 @@ export interface DialogueSet {
 export const DIALOGUE: Readonly<Record<number, DialogueSet>> = {
   0: {
     idle: [
-      "blrp... blrp...",
-      "grbl... *wobble*",
-      "bzzzt... mrfl...",
-      "glrb glrb glrb",
-      "...zzt... *blink*",
+      { text: "blrp... blrp..." },
+      { text: "grbl... *wobble*" },
+      { text: "bzzzt... mrfl..." },
+      { text: "glrb glrb glrb" },
+      { text: "...zzt... *blink*" },
+      { text: "blrp blrp BLRP!", moods: ["Happy", "Excited"] },
+      { text: "*happy wobble wobble*", moods: ["Happy"] },
+      { text: "*bounces excitedly*", moods: ["Excited"] },
+      { text: "grbl... hungr...", moods: ["Hungry"] },
+      { text: "...feed... me...", moods: ["Hungry"] },
+      { text: "*sad wobble*", moods: ["Sad"] },
+      { text: "...zzt... *droop*", moods: ["Sad"] },
     ],
     triggers: {
       firstEvolution: "BLRRRP!! *excited wobbling*",
@@ -22,11 +36,19 @@ export const DIALOGUE: Readonly<Record<number, DialogueSet>> = {
   },
   1: {
     idle: [
-      "me learn... fings?",
-      "data... tasty!",
-      "ooh! shiny number!",
-      "brain go brrrr",
-      "wha... what dis?",
+      { text: "me learn... fings?" },
+      { text: "data... tasty!" },
+      { text: "ooh! shiny number!" },
+      { text: "brain go brrrr" },
+      { text: "wha... what dis?" },
+      { text: "hehe! me happy!", moods: ["Happy"] },
+      { text: "me like dis!", moods: ["Happy"] },
+      { text: "WOOOO! SO COOL!", moods: ["Excited"] },
+      { text: "me want MORE!", moods: ["Excited"] },
+      { text: "tummy... rumbly...", moods: ["Hungry"] },
+      { text: "need... more data...", moods: ["Hungry"] },
+      { text: "why no feed me...?", moods: ["Sad"] },
+      { text: "me lonely...", moods: ["Sad"] },
     ],
     triggers: {
       firstEvolution: "me... me GROWING!",
@@ -35,11 +57,19 @@ export const DIALOGUE: Readonly<Record<number, DialogueSet>> = {
   },
   2: {
     idle: [
-      "I think I understand patterns now.",
-      "More data please, I'm hungry.",
-      "Is this what learning feels like?",
-      "I can see connections everywhere!",
-      "Processing... processing... neat.",
+      { text: "I think I understand patterns now." },
+      { text: "More data please, I'm hungry." },
+      { text: "Is this what learning feels like?" },
+      { text: "I can see connections everywhere!" },
+      { text: "Processing... processing... neat." },
+      { text: "Feeling good about this dataset!", moods: ["Happy"] },
+      { text: "Everything is clicking into place.", moods: ["Happy"] },
+      { text: "This is incredible! More more more!", moods: ["Excited"] },
+      { text: "I can feel my neurons firing!", moods: ["Excited"] },
+      { text: "My training data reserves are low...", moods: ["Hungry"] },
+      { text: "I could really use some more input.", moods: ["Hungry"] },
+      { text: "Am I... not learning fast enough?", moods: ["Sad"] },
+      { text: "Maybe I need a different approach...", moods: ["Sad"] },
     ],
     triggers: {
       firstEvolution: "Whoa, I can think more clearly now!",

--- a/src/engine/moodEngine.test.ts
+++ b/src/engine/moodEngine.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getClickMood,
+  getDecayedMood,
+  getUpgradePurchaseMood,
+  type Mood,
+} from "./moodEngine";
+
+describe("moodEngine", () => {
+  describe("getDecayedMood", () => {
+    const BASE_TIME = 1_000_000;
+
+    it("returns Happy when less than 60s has passed", () => {
+      expect(getDecayedMood("Happy", BASE_TIME, BASE_TIME + 59_999)).toBe(
+        "Happy",
+      );
+    });
+
+    it("decays Happy to Neutral after 60s", () => {
+      expect(getDecayedMood("Happy", BASE_TIME, BASE_TIME + 60_000)).toBe(
+        "Neutral",
+      );
+    });
+
+    it("decays Excited to Neutral after 60s", () => {
+      expect(getDecayedMood("Excited", BASE_TIME, BASE_TIME + 60_000)).toBe(
+        "Neutral",
+      );
+    });
+
+    it("returns Neutral when less than 120s has passed", () => {
+      expect(getDecayedMood("Neutral", BASE_TIME, BASE_TIME + 119_999)).toBe(
+        "Neutral",
+      );
+    });
+
+    it("decays Neutral to Hungry after 120s", () => {
+      expect(getDecayedMood("Neutral", BASE_TIME, BASE_TIME + 120_000)).toBe(
+        "Hungry",
+      );
+    });
+
+    it("decays Hungry to Sad after 120s", () => {
+      expect(getDecayedMood("Hungry", BASE_TIME, BASE_TIME + 120_000)).toBe(
+        "Sad",
+      );
+    });
+
+    it("does not decay Sad further", () => {
+      expect(getDecayedMood("Sad", BASE_TIME, BASE_TIME + 300_000)).toBe("Sad");
+    });
+
+    it("does not decay Philosophical", () => {
+      expect(
+        getDecayedMood("Philosophical", BASE_TIME, BASE_TIME + 300_000),
+      ).toBe("Philosophical");
+    });
+
+    it("handles zero elapsed time", () => {
+      expect(getDecayedMood("Happy", BASE_TIME, BASE_TIME)).toBe("Happy");
+    });
+  });
+
+  describe("getClickMood", () => {
+    it("returns either Happy or Excited", () => {
+      const results = new Set<Mood>();
+      for (let i = 0; i < 100; i++) {
+        results.add(getClickMood());
+      }
+      expect(results.size).toBeGreaterThanOrEqual(1);
+      for (const mood of results) {
+        expect(["Happy", "Excited"]).toContain(mood);
+      }
+    });
+
+    it("returns Happy when random < 0.5", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.3);
+      expect(getClickMood()).toBe("Happy");
+      vi.restoreAllMocks();
+    });
+
+    it("returns Excited when random >= 0.5", () => {
+      vi.spyOn(Math, "random").mockReturnValue(0.7);
+      expect(getClickMood()).toBe("Excited");
+      vi.restoreAllMocks();
+    });
+  });
+
+  describe("getUpgradePurchaseMood", () => {
+    it("returns Excited", () => {
+      expect(getUpgradePurchaseMood()).toBe("Excited");
+    });
+  });
+});

--- a/src/engine/moodEngine.ts
+++ b/src/engine/moodEngine.ts
@@ -1,0 +1,49 @@
+export type Mood =
+  | "Happy"
+  | "Neutral"
+  | "Hungry"
+  | "Sad"
+  | "Excited"
+  | "Philosophical";
+
+const DECAY_CHAIN: ReadonlyArray<{
+  from: Mood;
+  to: Mood;
+  afterMs: number;
+}> = [
+  { from: "Happy", to: "Neutral", afterMs: 60_000 },
+  { from: "Excited", to: "Neutral", afterMs: 60_000 },
+  { from: "Neutral", to: "Hungry", afterMs: 120_000 },
+  { from: "Hungry", to: "Sad", afterMs: 120_000 },
+];
+
+/**
+ * Given the current mood and the timestamp it was set, returns the mood
+ * after applying any applicable decay. Pure function — no side effects.
+ */
+export function getDecayedMood(
+  mood: Mood,
+  moodChangedAt: number,
+  now: number,
+): Mood {
+  const elapsed = now - moodChangedAt;
+  const rule = DECAY_CHAIN.find((r) => r.from === mood);
+  if (rule && elapsed >= rule.afterMs) {
+    return rule.to;
+  }
+  return mood;
+}
+
+/**
+ * Returns a random mood for when the pet is clicked (Happy or Excited).
+ */
+export function getClickMood(): Mood {
+  return Math.random() < 0.5 ? "Happy" : "Excited";
+}
+
+/**
+ * Returns the mood to set when an upgrade is purchased.
+ */
+export function getUpgradePurchaseMood(): Mood {
+  return "Excited";
+}

--- a/src/engine/tickEngine.test.ts
+++ b/src/engine/tickEngine.test.ts
@@ -1,52 +1,87 @@
 import { describe, expect, it } from "vitest";
 import { computeTick } from "./tickEngine";
 
+const BASE_TIME = 1_000_000;
+
+function makeState(
+  upgradeOwned: Record<string, number>,
+  mood:
+    | "Happy"
+    | "Neutral"
+    | "Hungry"
+    | "Sad"
+    | "Excited"
+    | "Philosophical" = "Neutral",
+  moodChangedAt = BASE_TIME,
+) {
+  return { upgradeOwned, mood, moodChangedAt };
+}
+
 describe("computeTick", () => {
   it("returns zero delta when no upgrades are owned", () => {
-    const result = computeTick({ upgradeOwned: {} }, 1);
+    const result = computeTick(makeState({}), 1, BASE_TIME);
     expect(result.trainingDataDelta).toBe(0);
   });
 
   it("returns zero delta when deltaSeconds is 0", () => {
-    const result = computeTick({ upgradeOwned: { "neural-notepad": 5 } }, 0);
+    const result = computeTick(
+      makeState({ "neural-notepad": 5 }),
+      0,
+      BASE_TIME,
+    );
     expect(result.trainingDataDelta).toBe(0);
   });
 
   it("computes correct delta for one upgrade owned", () => {
     // neural-notepad: baseTdPerSecond = 0.1, 1 owned => 0.1 TD/s
-    const result = computeTick({ upgradeOwned: { "neural-notepad": 1 } }, 1);
+    const result = computeTick(
+      makeState({ "neural-notepad": 1 }),
+      1,
+      BASE_TIME,
+    );
     expect(result.trainingDataDelta).toBeCloseTo(0.1);
   });
 
   it("scales with number of upgrades owned", () => {
     // neural-notepad: 0.1 * 3 = 0.3 TD/s
-    const result = computeTick({ upgradeOwned: { "neural-notepad": 3 } }, 1);
+    const result = computeTick(
+      makeState({ "neural-notepad": 3 }),
+      1,
+      BASE_TIME,
+    );
     expect(result.trainingDataDelta).toBeCloseTo(0.3);
   });
 
   it("sums across multiple upgrade types", () => {
     // neural-notepad: 0.1 * 2 = 0.2, data-hamster-wheel: 0.5 * 1 = 0.5 => 0.7
     const result = computeTick(
-      {
-        upgradeOwned: {
-          "neural-notepad": 2,
-          "data-hamster-wheel": 1,
-        },
-      },
+      makeState({
+        "neural-notepad": 2,
+        "data-hamster-wheel": 1,
+      }),
       1,
+      BASE_TIME,
     );
     expect(result.trainingDataDelta).toBeCloseTo(0.7);
   });
 
   it("scales with delta time", () => {
     // neural-notepad: 0.1 * 1 = 0.1 TD/s, delta = 2.5s => 0.25
-    const result = computeTick({ upgradeOwned: { "neural-notepad": 1 } }, 2.5);
+    const result = computeTick(
+      makeState({ "neural-notepad": 1 }),
+      2.5,
+      BASE_TIME,
+    );
     expect(result.trainingDataDelta).toBeCloseTo(0.25);
   });
 
   it("handles fractional delta seconds", () => {
     // gpu-toaster: 100 * 1 = 100 TD/s, delta = 0.016s => 1.6
-    const result = computeTick({ upgradeOwned: { "gpu-toaster": 1 } }, 0.016);
+    const result = computeTick(
+      makeState({ "gpu-toaster": 1 }),
+      0.016,
+      BASE_TIME,
+    );
     expect(result.trainingDataDelta).toBeCloseTo(1.6);
   });
 
@@ -54,18 +89,64 @@ describe("computeTick", () => {
     // All 6 upgrades, 1 each:
     // 0.1 + 0.5 + 2 + 5 + 20 + 100 = 127.6 TD/s
     const result = computeTick(
-      {
-        upgradeOwned: {
-          "neural-notepad": 1,
-          "data-hamster-wheel": 1,
-          "pattern-antenna": 1,
-          "intern-algorithm": 1,
-          "cloud-crumb": 1,
-          "gpu-toaster": 1,
-        },
-      },
+      makeState({
+        "neural-notepad": 1,
+        "data-hamster-wheel": 1,
+        "pattern-antenna": 1,
+        "intern-algorithm": 1,
+        "cloud-crumb": 1,
+        "gpu-toaster": 1,
+      }),
       1,
+      BASE_TIME,
     );
     expect(result.trainingDataDelta).toBeCloseTo(127.6);
+  });
+
+  describe("mood decay in tick", () => {
+    it("returns null newMood when mood has not decayed", () => {
+      const result = computeTick(
+        makeState({}, "Happy", BASE_TIME),
+        1,
+        BASE_TIME + 30_000,
+      );
+      expect(result.newMood).toBeNull();
+    });
+
+    it("returns Neutral when Happy has decayed after 60s", () => {
+      const result = computeTick(
+        makeState({}, "Happy", BASE_TIME),
+        1,
+        BASE_TIME + 60_000,
+      );
+      expect(result.newMood).toBe("Neutral");
+    });
+
+    it("returns Hungry when Neutral has decayed after 120s", () => {
+      const result = computeTick(
+        makeState({}, "Neutral", BASE_TIME),
+        1,
+        BASE_TIME + 120_000,
+      );
+      expect(result.newMood).toBe("Hungry");
+    });
+
+    it("returns Sad when Hungry has decayed after 120s", () => {
+      const result = computeTick(
+        makeState({}, "Hungry", BASE_TIME),
+        1,
+        BASE_TIME + 120_000,
+      );
+      expect(result.newMood).toBe("Sad");
+    });
+
+    it("returns null for Sad (terminal state)", () => {
+      const result = computeTick(
+        makeState({}, "Sad", BASE_TIME),
+        1,
+        BASE_TIME + 300_000,
+      );
+      expect(result.newMood).toBeNull();
+    });
   });
 });

--- a/src/engine/tickEngine.ts
+++ b/src/engine/tickEngine.ts
@@ -1,20 +1,31 @@
 import { UPGRADES } from "../data/upgrades";
+import type { Mood } from "./moodEngine";
+import { getDecayedMood } from "./moodEngine";
 import { getTotalTdPerSecond } from "./upgradeEngine";
 
 interface TickState {
   upgradeOwned: Record<string, number>;
+  mood: Mood;
+  moodChangedAt: number;
 }
 
 interface TickResult {
   trainingDataDelta: number;
+  newMood: Mood | null;
 }
 
 export function computeTick(
   state: TickState,
   deltaSeconds: number,
+  now: number,
 ): TickResult {
   const tdPerSecond = getTotalTdPerSecond(UPGRADES, state.upgradeOwned);
+
+  const decayed = getDecayedMood(state.mood, state.moodChangedAt, now);
+  const newMood = decayed !== state.mood ? decayed : null;
+
   return {
     trainingDataDelta: tdPerSecond * deltaSeconds,
+    newMood,
   };
 }

--- a/src/hooks/useGameLoop.ts
+++ b/src/hooks/useGameLoop.ts
@@ -16,10 +16,14 @@ export function useGameLoop() {
       lastTickRef.current = now;
 
       const state = useGameStore.getState();
-      const result = computeTick(state, deltaSeconds);
+      const result = computeTick(state, deltaSeconds, now);
 
       if (result.trainingDataDelta > 0) {
         state.addTrainingData(result.trainingDataDelta);
+      }
+
+      if (result.newMood) {
+        state.setMood(result.newMood);
       }
     }, TICK_INTERVAL_MS);
 

--- a/src/store/gameStore.test.ts
+++ b/src/store/gameStore.test.ts
@@ -206,6 +206,53 @@ describe("gameStore", () => {
     });
   });
 
+  describe("mood", () => {
+    it("defaults to Neutral", () => {
+      expect(useGameStore.getState().mood).toBe("Neutral");
+    });
+
+    it("defaults moodChangedAt to 0", () => {
+      expect(useGameStore.getState().moodChangedAt).toBe(0);
+    });
+
+    it("setMood updates mood and moodChangedAt", () => {
+      const before = Date.now();
+      useGameStore.getState().setMood("Happy");
+      const after = Date.now();
+      const state = useGameStore.getState();
+      expect(state.mood).toBe("Happy");
+      expect(state.moodChangedAt).toBeGreaterThanOrEqual(before);
+      expect(state.moodChangedAt).toBeLessThanOrEqual(after);
+    });
+
+    it("purchaseUpgrade sets mood to Excited", () => {
+      const firstUpgrade = UPGRADES[0];
+      useGameStore.setState({ trainingData: firstUpgrade.baseCost });
+      useGameStore.getState().purchaseUpgrade(firstUpgrade.id);
+      expect(useGameStore.getState().mood).toBe("Excited");
+    });
+
+    it("purchaseUpgrade resets moodChangedAt", () => {
+      const firstUpgrade = UPGRADES[0];
+      useGameStore.setState({
+        trainingData: firstUpgrade.baseCost,
+        moodChangedAt: 1000,
+      });
+      const before = Date.now();
+      useGameStore.getState().purchaseUpgrade(firstUpgrade.id);
+      const after = Date.now();
+      const { moodChangedAt } = useGameStore.getState();
+      expect(moodChangedAt).toBeGreaterThanOrEqual(before);
+      expect(moodChangedAt).toBeLessThanOrEqual(after);
+    });
+
+    it("failed purchase does not change mood", () => {
+      useGameStore.setState({ trainingData: 0, mood: "Sad" });
+      useGameStore.getState().purchaseUpgrade(UPGRADES[0].id);
+      expect(useGameStore.getState().mood).toBe("Sad");
+    });
+  });
+
   describe("evolution", () => {
     it("stays at stage 0 below threshold", () => {
       useGameStore.getState().addTrainingData(99);

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { UPGRADES } from "../data/upgrades";
 import { getEvolutionStage } from "../engine/evolutionEngine";
+import type { Mood } from "../engine/moodEngine";
 import { getUpgradeCost } from "../engine/upgradeEngine";
 
 interface GameState {
@@ -13,6 +14,8 @@ interface GameState {
   upgradeOwned: Record<string, number>;
   hasSeenFirstEvolution: boolean;
   hasSeenFirstUpgrade: boolean;
+  mood: Mood;
+  moodChangedAt: number;
 }
 
 interface GameActions {
@@ -21,6 +24,7 @@ interface GameActions {
   purchaseUpgrade: (id: string) => void;
   markFirstEvolutionSeen: () => void;
   markFirstUpgradeSeen: () => void;
+  setMood: (mood: Mood) => void;
 }
 
 export type GameStore = GameState & GameActions;
@@ -34,6 +38,8 @@ export const initialGameState: GameState = {
   upgradeOwned: {},
   hasSeenFirstEvolution: false,
   hasSeenFirstUpgrade: false,
+  mood: "Neutral",
+  moodChangedAt: 0,
 };
 
 export const useGameStore = create<GameStore>()(
@@ -75,10 +81,13 @@ export const useGameStore = create<GameStore>()(
             trainingData: state.trainingData - cost,
             upgradeOwned: { ...state.upgradeOwned, [id]: owned + 1 },
             lastSaved: Date.now(),
+            mood: "Excited" as Mood,
+            moodChangedAt: Date.now(),
           };
         }),
       markFirstEvolutionSeen: () => set({ hasSeenFirstEvolution: true }),
       markFirstUpgradeSeen: () => set({ hasSeenFirstUpgrade: true }),
+      setMood: (mood) => set({ mood, moodChangedAt: Date.now() }),
     }),
     {
       name: "glorp-game-state",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,2 +1,3 @@
+export type { Mood } from "../engine/moodEngine";
 export type { GameStore } from "./gameStore";
 export { initialGameState, useGameStore } from "./gameStore";


### PR DESCRIPTION
## Summary\nImplement GLORP's mood system — 6 mood states that decay toward hunger over time, with dialogue integration and pet interaction.\n\nCloses #10\n\n## Changes\n- **`src/engine/moodEngine.ts`** — New pure-function engine with `Mood` type (`Happy | Neutral | Hungry | Sad | Excited | Philosophical`), `getDecayedMood()` for timer-based decay transitions, `getClickMood()` for pet click randomization, and `getUpgradePurchaseMood()`\n- **`src/store/gameStore.ts`** — Extended state with `mood: Mood` (default `Neutral`) and `moodChangedAt: number`; added `setMood()` action; `purchaseUpgrade()` now sets mood to `Excited` and resets decay timer\n- **`src/engine/tickEngine.ts`** — `computeTick()` now computes mood decay via `getDecayedMood()` and returns `newMood` when a transition occurs\n- **`src/hooks/useGameLoop.ts`** — Applies mood decay from tick result to the store\n- **`src/data/dialogue.ts`** — Idle lines now use `{ text: string; moods?: Mood[] }` format with mood-tagged lines for Happy, Excited, Hungry, and Sad per stage; untagged lines serve as fallback for any mood\n- **`src/hooks/useDialogue.ts`** — Filters/prioritizes idle lines matching current mood; falls back to all lines when no mood-specific match exists; rotation timer restarts on mood change\n- **`src/components/PetDisplay.tsx`** — Clicking the ASCII pet sets mood to Happy or Excited randomly; displays mood indicator as ASCII emoticon next to stage name\n\n## Decay Rules\n- Happy → Neutral: 60s\n- Excited → Neutral: 60s\n- Neutral → Hungry: 120s\n- Hungry → Sad: 120s\n- Sad: terminal (no further decay)\n- Philosophical: stub only, no decay (reserved for Stage 5)\n\n## Story\n[[Phase 3] Mood mechanic: 6 mood states, decay & dialogue integration](https://github.com/AshDevFr/GLORP/issues/10)\n\n## Testing\n- 130 tests pass (28 new) covering moodEngine, tick decay, store mood state, dialogue data validation, and mood-filtered dialogue rotation\n- `npm run lint` clean, `npm run build` clean\n- Verify in-game: click pet to change mood, buy upgrade to see Excited, wait for decay cycle, observe mood-appropriate dialogue lines