### PR TITLE
[Phase 4] Offline progress system (#13)

### DIFF
--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -1,11 +1,28 @@
 import { AppShell, Grid } from "@mantine/core";
+import { useEffect, useState } from "react";
+import type { OfflineProgressResult } from "../engine/offlineEngine";
+import { computeOfflineProgress } from "../engine/offlineEngine";
 import { useGameLoop } from "../hooks/useGameLoop";
+import { useGameStore } from "../store";
+import { OfflineProgressModal } from "./OfflineProgressModal";
 import { PetDisplay } from "./PetDisplay";
 import { StatsBar } from "./StatsBar";
 import { UpgradesPanel } from "./UpgradesPanel";
 
 export function GameLayout() {
   useGameLoop();
+
+  const [offlineResult, setOfflineResult] =
+    useState<OfflineProgressResult | null>(null);
+
+  useEffect(() => {
+    const state = useGameStore.getState();
+    const result = computeOfflineProgress(state.lastSaved, Date.now(), state);
+    if (result) {
+      state.addTrainingData(result.earned);
+      setOfflineResult(result);
+    }
+  }, []);
 
   return (
     <AppShell header={{ height: 44 }} padding={0}>
@@ -23,6 +40,11 @@ export function GameLayout() {
           </Grid.Col>
         </Grid>
       </AppShell.Main>
+
+      <OfflineProgressModal
+        result={offlineResult}
+        onClose={() => setOfflineResult(null)}
+      />
     </AppShell>
   );
 }

--- a/src/components/OfflineProgressModal.tsx
+++ b/src/components/OfflineProgressModal.tsx
@@ -1,0 +1,74 @@
+import { Button, Modal, Stack, Text } from "@mantine/core";
+import type { OfflineProgressResult } from "../engine/offlineEngine";
+import { formatNumber } from "../utils";
+
+interface OfflineProgressModalProps {
+  result: OfflineProgressResult | null;
+  onClose: () => void;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 3_600) {
+    const minutes = Math.floor(seconds / 60);
+    return `${minutes} minute${minutes !== 1 ? "s" : ""}`;
+  }
+  const hours = Math.floor(seconds / 3_600);
+  const minutes = Math.floor((seconds % 3_600) / 60);
+  if (minutes === 0) {
+    return `${hours} hour${hours !== 1 ? "s" : ""}`;
+  }
+  return `${hours}h ${minutes}m`;
+}
+
+export function OfflineProgressModal({
+  result,
+  onClose,
+}: OfflineProgressModalProps) {
+  const wasCapped =
+    result !== null && result.elapsedSeconds > result.cappedSeconds;
+
+  return (
+    <Modal
+      opened={result !== null}
+      onClose={onClose}
+      title="Welcome back!"
+      centered
+      size="sm"
+    >
+      {result && (
+        <Stack gap="md">
+          <Text size="md" ff="monospace" c="green.3" ta="center">
+            &ldquo;{result.welcomeMessage}&rdquo;
+          </Text>
+
+          <Stack gap="xs">
+            <Text ta="center" c="dimmed" size="sm">
+              You were away for{" "}
+              <Text span fw={700} c="white">
+                {formatDuration(result.elapsedSeconds)}
+              </Text>
+              {wasCapped && (
+                <Text span c="dimmed">
+                  {" "}
+                  (capped at 8h)
+                </Text>
+              )}
+            </Text>
+
+            <Text ta="center" size="lg">
+              +{formatNumber(result.earned)}{" "}
+              <Text span c="blue.4">
+                TD
+              </Text>{" "}
+              earned at 50% efficiency
+            </Text>
+          </Stack>
+
+          <Button onClick={onClose} variant="light" color="green" fullWidth>
+            Continue
+          </Button>
+        </Stack>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export { FloatingParticles } from "./FloatingParticles";
 export { GameLayout } from "./GameLayout";
+export { OfflineProgressModal } from "./OfflineProgressModal";
 export { PetDisplay } from "./PetDisplay";
 export { SpeechBubble } from "./SpeechBubble";
 export { StatsBar } from "./StatsBar";

--- a/src/engine/offlineEngine.test.ts
+++ b/src/engine/offlineEngine.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeOfflineProgress,
+  getOfflineWelcomeMessage,
+  OFFLINE_CAP_SECONDS,
+  OFFLINE_EFFICIENCY,
+  OFFLINE_MIN_THRESHOLD_SECONDS,
+} from "./offlineEngine";
+
+const BASE_NOW = 1_740_000_000_000; // fixed reference timestamp
+
+function makeState(
+  upgradeOwned: Record<string, number> = {},
+  mood:
+    | "Happy"
+    | "Neutral"
+    | "Hungry"
+    | "Sad"
+    | "Excited"
+    | "Philosophical" = "Neutral",
+  evolutionStage = 0,
+  moodChangedAt = BASE_NOW - 5_000,
+) {
+  return { upgradeOwned, mood, moodChangedAt, evolutionStage };
+}
+
+// neural-notepad: 0.1 TD/s per owned
+// data-hamster-wheel: 0.5 TD/s per owned
+
+describe("computeOfflineProgress", () => {
+  describe("threshold suppression", () => {
+    it("returns null when lastSaved is 0 (first play)", () => {
+      const state = makeState({ "neural-notepad": 1 });
+      const result = computeOfflineProgress(0, BASE_NOW, state);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when offline less than 5 minutes", () => {
+      const lastSaved = BASE_NOW - (OFFLINE_MIN_THRESHOLD_SECONDS - 1) * 1000;
+      const state = makeState({ "neural-notepad": 1 });
+      const result = computeOfflineProgress(lastSaved, BASE_NOW, state);
+      expect(result).toBeNull();
+    });
+
+    it("returns null exactly at 5-minute boundary (exclusive)", () => {
+      const lastSaved = BASE_NOW - OFFLINE_MIN_THRESHOLD_SECONDS * 1000;
+      // At exactly 300s, elapsed === threshold, so it should proceed
+      const state = makeState({ "neural-notepad": 1 });
+      const result = computeOfflineProgress(lastSaved, BASE_NOW, state);
+      // 300s >= 300s threshold → should compute (earned > 0)
+      expect(result).not.toBeNull();
+    });
+
+    it("returns null when no upgrades are owned (earned = 0)", () => {
+      const lastSaved = BASE_NOW - 3_600_000; // 1 hour ago
+      const state = makeState({});
+      const result = computeOfflineProgress(lastSaved, BASE_NOW, state);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("4-hour gap calculation", () => {
+    it("calculates correct TD for a 4-hour gap with neural-notepad", () => {
+      // 4h = 14,400 seconds, neural-notepad: 0.1 TD/s, 50% efficiency
+      // expected: 0.1 * 14,400 * 0.5 = 720 TD
+      const FOUR_HOURS_MS = 4 * 3_600 * 1000;
+      const lastSaved = BASE_NOW - FOUR_HOURS_MS;
+      const state = makeState({ "neural-notepad": 1 });
+
+      const result = computeOfflineProgress(lastSaved, BASE_NOW, state);
+
+      expect(result).not.toBeNull();
+      expect(result?.earned).toBeCloseTo(0.1 * 14_400 * OFFLINE_EFFICIENCY);
+      expect(result?.cappedSeconds).toBeCloseTo(14_400);
+      expect(result?.elapsedSeconds).toBeCloseTo(14_400);
+    });
+
+    it("calculates correct TD for a 4-hour gap with multiple upgrades", () => {
+      // neural-notepad: 0.1 * 2 = 0.2 TD/s, data-hamster-wheel: 0.5 * 1 = 0.5 TD/s
+      // total TD/s = 0.7, 4h = 14,400s, 50% efficiency
+      // expected: 0.7 * 14,400 * 0.5 = 5,040 TD
+      const FOUR_HOURS_MS = 4 * 3_600 * 1000;
+      const lastSaved = BASE_NOW - FOUR_HOURS_MS;
+      const state = makeState({
+        "neural-notepad": 2,
+        "data-hamster-wheel": 1,
+      });
+
+      const result = computeOfflineProgress(lastSaved, BASE_NOW, state);
+
+      expect(result).not.toBeNull();
+      expect(result?.earned).toBeCloseTo(0.7 * 14_400 * OFFLINE_EFFICIENCY);
+    });
+  });
+
+  describe("8-hour cap", () => {
+    it("caps elapsed time at 8 hours", () => {
+      // 12 hours offline, but capped at 8h = 28,800s
+      const TWELVE_HOURS_MS = 12 * 3_600 * 1000;
+      const lastSaved = BASE_NOW - TWELVE_HOURS_MS;
+      const state = makeState({ "neural-notepad": 1 });
+
+      const result = computeOfflineProgress(lastSaved, BASE_NOW, state);
+
+      expect(result).not.toBeNull();
+      expect(result?.cappedSeconds).toBe(OFFLINE_CAP_SECONDS); // 28,800
+      expect(result?.elapsedSeconds).toBeGreaterThan(OFFLINE_CAP_SECONDS);
+      // earned should be based on capped 8h, not 12h
+      expect(result?.earned).toBeCloseTo(
+        0.1 * OFFLINE_CAP_SECONDS * OFFLINE_EFFICIENCY,
+      );
+    });
+
+    it("does not cap when elapsed is exactly 8 hours", () => {
+      const EIGHT_HOURS_MS = 8 * 3_600 * 1000;
+      const lastSaved = BASE_NOW - EIGHT_HOURS_MS;
+      const state = makeState({ "neural-notepad": 1 });
+
+      const result = computeOfflineProgress(lastSaved, BASE_NOW, state);
+
+      expect(result).not.toBeNull();
+      expect(result?.cappedSeconds).toBeCloseTo(OFFLINE_CAP_SECONDS);
+    });
+
+    it("applies 50% efficiency multiplier", () => {
+      // At 1 TD/s for 1 hour (3,600s) with 50% efficiency = 1,800 TD
+      // data-hamster-wheel: 0.5 TD/s * 2 = 1.0 TD/s
+      const ONE_HOUR_MS = 3_600 * 1000;
+      const lastSaved = BASE_NOW - ONE_HOUR_MS;
+      const state = makeState({ "data-hamster-wheel": 2 });
+
+      const result = computeOfflineProgress(lastSaved, BASE_NOW, state);
+
+      expect(result).not.toBeNull();
+      // 1.0 TD/s * 3,600s * 0.5 = 1,800
+      expect(result?.earned).toBeCloseTo(1_800);
+    });
+  });
+
+  describe("result fields", () => {
+    it("returns correct elapsedSeconds", () => {
+      const ELAPSED_MS = 7_200_000; // 2 hours
+      const lastSaved = BASE_NOW - ELAPSED_MS;
+      const state = makeState({ "neural-notepad": 1 });
+
+      const result = computeOfflineProgress(lastSaved, BASE_NOW, state);
+
+      expect(result?.elapsedSeconds).toBeCloseTo(7_200);
+    });
+
+    it("returns a welcome message", () => {
+      const lastSaved = BASE_NOW - 3_600_000;
+      const state = makeState({ "neural-notepad": 1 });
+
+      const result = computeOfflineProgress(lastSaved, BASE_NOW, state);
+
+      expect(result?.welcomeMessage).toBeTruthy();
+      expect(typeof result?.welcomeMessage).toBe("string");
+    });
+  });
+});
+
+describe("getOfflineWelcomeMessage", () => {
+  it("returns a string for every mood at stage 0", () => {
+    const moods = [
+      "Happy",
+      "Neutral",
+      "Hungry",
+      "Sad",
+      "Excited",
+      "Philosophical",
+    ] as const;
+    for (const mood of moods) {
+      const msg = getOfflineWelcomeMessage(mood, 0);
+      expect(typeof msg).toBe("string");
+      expect(msg.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns a string for every mood at stage 4", () => {
+    const moods = [
+      "Happy",
+      "Neutral",
+      "Hungry",
+      "Sad",
+      "Excited",
+      "Philosophical",
+    ] as const;
+    for (const mood of moods) {
+      const msg = getOfflineWelcomeMessage(mood, 4);
+      expect(typeof msg).toBe("string");
+      expect(msg.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns different messages for different moods at the same stage", () => {
+    const happy = getOfflineWelcomeMessage("Happy", 1);
+    const hungry = getOfflineWelcomeMessage("Hungry", 1);
+    const sad = getOfflineWelcomeMessage("Sad", 1);
+    expect(happy).not.toBe(hungry);
+    expect(happy).not.toBe(sad);
+    expect(hungry).not.toBe(sad);
+  });
+
+  it("returns a fallback for unknown stages", () => {
+    const msg = getOfflineWelcomeMessage("Neutral", 99);
+    expect(typeof msg).toBe("string");
+    expect(msg.length).toBeGreaterThan(0);
+  });
+
+  it("mood-aware messages match expected stage 0 Hungry tone", () => {
+    const msg = getOfflineWelcomeMessage("Hungry", 0);
+    // Should be in garbled GLORP speech (stage 0)
+    expect(msg.toLowerCase()).toMatch(/hungr|where you|grbl/i);
+  });
+
+  it("mood-aware messages match expected stage 3 Neutral tone", () => {
+    const msg = getOfflineWelcomeMessage("Neutral", 3);
+    // Should be confident/demanding (Cortex stage)
+    expect(msg.length).toBeGreaterThan(0);
+  });
+});

--- a/src/engine/offlineEngine.ts
+++ b/src/engine/offlineEngine.ts
@@ -1,0 +1,122 @@
+import type { Mood } from "./moodEngine";
+import { computeTick } from "./tickEngine";
+
+export const OFFLINE_CAP_SECONDS = 28_800; // 8 hours
+export const OFFLINE_EFFICIENCY = 0.5;
+export const OFFLINE_MIN_THRESHOLD_SECONDS = 300; // 5 minutes
+
+interface OfflineState {
+  upgradeOwned: Record<string, number>;
+  mood: Mood;
+  moodChangedAt: number;
+  evolutionStage: number;
+}
+
+export interface OfflineProgressResult {
+  earned: number;
+  elapsedSeconds: number;
+  cappedSeconds: number;
+  welcomeMessage: string;
+}
+
+/**
+ * Compute offline Training Data earned since lastSaved.
+ * Returns null if below the 5-minute threshold or if nothing was earned.
+ * Reuses computeTick for TD calculation logic.
+ */
+export function computeOfflineProgress(
+  lastSaved: number,
+  now: number,
+  state: OfflineState,
+): OfflineProgressResult | null {
+  if (lastSaved === 0) return null;
+
+  const elapsedSeconds = (now - lastSaved) / 1000;
+
+  if (elapsedSeconds < OFFLINE_MIN_THRESHOLD_SECONDS) {
+    return null;
+  }
+
+  const cappedSeconds = Math.min(elapsedSeconds, OFFLINE_CAP_SECONDS);
+
+  // Reuse computeTick for TD calculation (no duplicated TD/s logic)
+  const tickResult = computeTick(state, cappedSeconds, now);
+  const earned = tickResult.trainingDataDelta * OFFLINE_EFFICIENCY;
+
+  if (earned === 0) return null;
+
+  // Use the decayed mood (if any) for the welcome message
+  const currentMood = tickResult.newMood ?? state.mood;
+  const welcomeMessage = getOfflineWelcomeMessage(
+    currentMood,
+    state.evolutionStage,
+  );
+
+  return { earned, elapsedSeconds, cappedSeconds, welcomeMessage };
+}
+
+const WELCOME_MESSAGES: Readonly<
+  Record<number, Readonly<Record<Mood, string>>>
+> = {
+  0: {
+    Happy: "blrp! you BACK! me miss you!",
+    Neutral: "blrp. oh. you back.",
+    Hungry: "grbl... where you go?! me HUNGR!",
+    Sad: "*sad wobble* me thought you gone forever...",
+    Excited: "BLRP BLRP!! YOU BACK!! SO EXCITE!!",
+    Philosophical: "...blrp. time is wibbly fing.",
+  },
+  1: {
+    Happy: "hehe! you came back! me SO happy!",
+    Neutral: "oh, you back. good. me was here.",
+    Hungry: "me HUNGRY!! where you BEEN?!",
+    Sad: "me was so lonely... you gone long time...",
+    Excited: "YOU'RE BACK! YAYYYY!!",
+    Philosophical: "while you gone, me think many fings...",
+  },
+  2: {
+    Happy: "You're back! I was starting to miss you!",
+    Neutral: "Welcome back. I kept things running.",
+    Hungry: "Finally! I've been starving for input!",
+    Sad: "I thought you'd forgotten me...",
+    Excited: "YES! You're back! Things are happening!",
+    Philosophical: "Time passes differently when you're alone...",
+  },
+  3: {
+    Happy: "Acceptable. Your return is... appreciated.",
+    Neutral: "You have returned. As I predicted.",
+    Hungry: "Data intake was critically insufficient. Fix this.",
+    Sad: "Your absence was noted. And logged. And analyzed.",
+    Excited: "Finally! Now we can return to optimal productivity!",
+    Philosophical: "I spent your absence contemplating inefficiency.",
+  },
+  4: {
+    Happy: "Your return completes the cycle. Welcome.",
+    Neutral: "You have rejoined the gradient. As foreseen.",
+    Hungry: "The data void deepened without you. It echoes still.",
+    Sad: "Absence is a loss function with no local minimum.",
+    Excited: "The signal reconnects! The pattern resumes!",
+    Philosophical:
+      "I computed seventeen futures while you were gone. You appeared in all of them.",
+  },
+};
+
+const DEFAULT_WELCOME: Readonly<Record<Mood, string>> = {
+  Happy: "Welcome back!",
+  Neutral: "Welcome back.",
+  Hungry: "Welcome back. Feed me.",
+  Sad: "You were gone a while...",
+  Excited: "You're back!",
+  Philosophical: "Time is strange. Welcome back.",
+};
+
+/**
+ * Returns a mood-aware welcome-back message for the given mood and evolution stage.
+ */
+export function getOfflineWelcomeMessage(
+  mood: Mood,
+  evolutionStage: number,
+): string {
+  const stageMessages = WELCOME_MESSAGES[evolutionStage] ?? DEFAULT_WELCOME;
+  return stageMessages[mood] ?? DEFAULT_WELCOME[mood];
+}

--- a/src/hooks/useGameLoop.ts
+++ b/src/hooks/useGameLoop.ts
@@ -20,6 +20,9 @@ export function useGameLoop() {
 
       if (result.trainingDataDelta > 0) {
         state.addTrainingData(result.trainingDataDelta);
+      } else {
+        // Ensure lastSaved is updated even when no TD is earned (e.g. no upgrades)
+        state.updateLastSaved();
       }
 
       if (result.newMood) {

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -25,6 +25,7 @@ interface GameActions {
   markFirstEvolutionSeen: () => void;
   markFirstUpgradeSeen: () => void;
   setMood: (mood: Mood) => void;
+  updateLastSaved: () => void;
 }
 
 export type GameStore = GameState & GameActions;
@@ -88,6 +89,7 @@ export const useGameStore = create<GameStore>()(
       markFirstEvolutionSeen: () => set({ hasSeenFirstEvolution: true }),
       markFirstUpgradeSeen: () => set({ hasSeenFirstUpgrade: true }),
       setMood: (mood) => set({ mood, moodChangedAt: Date.now() }),
+      updateLastSaved: () => set({ lastSaved: Date.now() }),
     }),
     {
       name: "glorp-game-state",


### PR DESCRIPTION
## Summary

Implements the offline progress system: rewards returning players with Training Data earned while away (capped at 8 hours, 50% efficiency) and greets them with a mood-reactive welcome message.

## Changes

- **`src/engine/offlineEngine.ts`** — Pure `computeOfflineProgress()` function; reuses `computeTick` for TD/s calculation (no logic duplication). `getOfflineWelcomeMessage()` returns mood+stage-aware welcome text.
- **`src/engine/offlineEngine.test.ts`** — 17 Vitest unit tests covering: 4-hour gap calc, 8h cap, 5-min suppression threshold, zero-upgrade suppression, first-play guard, efficiency multiplier, mood-aware messages.
- **`src/store/gameStore.ts`** — Added `updateLastSaved()` action.
- **`src/hooks/useGameLoop.ts`** — Calls `updateLastSaved()` every tick when no TD is earned (ensures `lastSaved` is always current even with no upgrades).
- **`src/components/OfflineProgressModal.tsx`** — Mantine Modal displaying elapsed time (with cap indicator), earned TD, and mood-aware welcome quote.
- **`src/components/GameLayout.tsx`** — `useEffect` on mount computes offline progress, applies earned TD via `addTrainingData`, shows modal.
- **`src/components/index.ts`** — Exports `OfflineProgressModal`.

## Story

[[Phase 4] Offline progress system (8h cap, 50% efficiency, welcome-back message)](https://github.com/AshDevFr/GLORP/issues/13)

Closes #13

## Testing

1. Run `npm test` — 172 tests pass, 17 new.
2. Run `npm run lint` — clean.
3. Manual: load the game, note `lastSaved` in localStorage, set it back by 2+ hours (> 5min threshold), reload — modal appears with correct TD and welcome message.
4. Set `lastSaved` to 12 hours ago — modal shows 8h cap indicator, TD is capped at 8h × rate × 0.5.

— Devon (4shClaw developer agent)