### PR TITLE
feat: Achievements system with 16 milestones, toast notifications, and modal (#15)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mantine/core": "8.3.15",
         "@mantine/hooks": "8.3.15",
+        "@mantine/notifications": "8.3.15",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "zustand": "5.0.11"
@@ -1281,6 +1282,31 @@
         "react": "^18.x || ^19.x"
       }
     },
+    "node_modules/@mantine/notifications": {
+      "version": "8.3.15",
+      "resolved": "https://registry.npmjs.org/@mantine/notifications/-/notifications-8.3.15.tgz",
+      "integrity": "sha512-CJGSv8oeLWyJIVPninU7Ud6vV6/UJKWZJwRGBNg2K0Ak0U0coFN3gW3H6G1Mh2zllNxb3K4fpMJNz4Iy0sCBFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mantine/store": "8.3.15",
+        "react-transition-group": "4.4.5"
+      },
+      "peerDependencies": {
+        "@mantine/core": "8.3.15",
+        "@mantine/hooks": "8.3.15",
+        "react": "^18.x || ^19.x",
+        "react-dom": "^18.x || ^19.x"
+      }
+    },
+    "node_modules/@mantine/store": {
+      "version": "8.3.15",
+      "resolved": "https://registry.npmjs.org/@mantine/store/-/store-8.3.15.tgz",
+      "integrity": "sha512-wdx91a73dM2G02YPIZ9i5UXPWfvjdf3qPAwSGnSsBFQg5uM/5CcPAOOQwlYIkvX1edUA5BFOk/4IjpEXSYUDeQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.x || ^19.x"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -2128,7 +2154,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -2194,6 +2219,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -2398,7 +2433,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -2466,6 +2500,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -2538,6 +2584,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -2634,6 +2689,23 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -2778,6 +2850,22 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/require-from-string": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@mantine/core": "8.3.15",
     "@mantine/hooks": "8.3.15",
+    "@mantine/notifications": "8.3.15",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "zustand": "5.0.11"

--- a/src/components/AchievementsModal.tsx
+++ b/src/components/AchievementsModal.tsx
@@ -1,0 +1,64 @@
+import { Modal, ScrollArea, Stack, Text } from "@mantine/core";
+import { ACHIEVEMENTS } from "../data/achievements";
+import { useGameStore } from "../store";
+
+export function AchievementsModal({
+  opened,
+  onClose,
+}: {
+  opened: boolean;
+  onClose: () => void;
+}) {
+  const unlockedAchievements = useGameStore((s) => s.unlockedAchievements);
+  const unlockedSet = new Set(unlockedAchievements);
+  const unlockedCount = unlockedAchievements.length;
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={
+        <Text ff="monospace" fw={700}>
+          Achievements ({unlockedCount}/{ACHIEVEMENTS.length})
+        </Text>
+      }
+      size="md"
+    >
+      <ScrollArea mah={480}>
+        <Stack gap="xs">
+          {ACHIEVEMENTS.map((a) => {
+            const isUnlocked = unlockedSet.has(a.id);
+            return (
+              <Stack
+                key={a.id}
+                gap={2}
+                p="xs"
+                style={{
+                  borderRadius: 4,
+                  background: isUnlocked
+                    ? "rgba(255,215,0,0.07)"
+                    : "rgba(255,255,255,0.03)",
+                  borderLeft: isUnlocked
+                    ? "3px solid var(--mantine-color-yellow-5)"
+                    : "3px solid var(--mantine-color-dark-4)",
+                }}
+              >
+                <Text
+                  size="sm"
+                  ff="monospace"
+                  fw={700}
+                  c={isUnlocked ? "yellow" : "dimmed"}
+                >
+                  {isUnlocked ? "★" : "☆"} {a.name}
+                </Text>
+                <Text size="xs" c="dimmed" ff="monospace">
+                  {a.description}
+                </Text>
+              </Stack>
+            );
+          })}
+        </Stack>
+      </ScrollArea>
+    </Modal>
+  );
+}

--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -1,9 +1,10 @@
-import { AppShell, Grid } from "@mantine/core";
+import { AppShell, Button, Grid, Group } from "@mantine/core";
 import { useEffect, useState } from "react";
 import type { OfflineProgressResult } from "../engine/offlineEngine";
 import { computeOfflineProgress } from "../engine/offlineEngine";
 import { useGameLoop } from "../hooks/useGameLoop";
 import { useGameStore } from "../store";
+import { AchievementsModal } from "./AchievementsModal";
 import { OfflineProgressModal } from "./OfflineProgressModal";
 import { PetDisplay } from "./PetDisplay";
 import { StatsBar } from "./StatsBar";
@@ -14,6 +15,8 @@ export function GameLayout() {
 
   const [offlineResult, setOfflineResult] =
     useState<OfflineProgressResult | null>(null);
+  const [achievementsOpen, setAchievementsOpen] = useState(false);
+  const unlockedCount = useGameStore((s) => s.unlockedAchievements.length);
 
   useEffect(() => {
     const state = useGameStore.getState();
@@ -27,7 +30,18 @@ export function GameLayout() {
   return (
     <AppShell header={{ height: 44 }} padding={0}>
       <AppShell.Header>
-        <StatsBar />
+        <Group h="100%" px="xs" justify="space-between" wrap="nowrap">
+          <StatsBar />
+          <Button
+            size="xs"
+            variant="subtle"
+            color="yellow"
+            onClick={() => setAchievementsOpen(true)}
+            style={{ fontFamily: "monospace", whiteSpace: "nowrap" }}
+          >
+            ★ {unlockedCount}
+          </Button>
+        </Group>
       </AppShell.Header>
 
       <AppShell.Main>
@@ -44,6 +58,10 @@ export function GameLayout() {
       <OfflineProgressModal
         result={offlineResult}
         onClose={() => setOfflineResult(null)}
+      />
+      <AchievementsModal
+        opened={achievementsOpen}
+        onClose={() => setAchievementsOpen(false)}
       />
     </AppShell>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export { AchievementsModal } from "./AchievementsModal";
 export { FloatingParticles } from "./FloatingParticles";
 export { GameLayout } from "./GameLayout";
 export { OfflineProgressModal } from "./OfflineProgressModal";

--- a/src/data/achievements.test.ts
+++ b/src/data/achievements.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import type { GameState } from "../store/gameStore";
+import { ACHIEVEMENTS } from "./achievements";
+
+const emptyState: GameState = {
+  trainingData: 0,
+  totalClicks: 0,
+  totalTdEarned: 0,
+  evolutionStage: 0,
+  lastSaved: 0,
+  upgradeOwned: {},
+  hasSeenFirstEvolution: false,
+  hasSeenFirstUpgrade: false,
+  mood: "Neutral",
+  moodChangedAt: 0,
+  wisdomTokens: 0,
+  rebirthCount: 0,
+  currentSpecies: "GLORP",
+  unlockedSpecies: ["GLORP"],
+  unlockedAchievements: [],
+};
+
+describe("ACHIEVEMENTS", () => {
+  it("defines at least 15 achievements", () => {
+    expect(ACHIEVEMENTS.length).toBeGreaterThanOrEqual(15);
+  });
+
+  it("every achievement has a non-empty id, name, and description", () => {
+    for (const a of ACHIEVEMENTS) {
+      expect(a.id.length).toBeGreaterThan(0);
+      expect(a.name.length).toBeGreaterThan(0);
+      expect(a.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("all achievement IDs are unique", () => {
+    const ids = ACHIEVEMENTS.map((a) => a.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it("all achievement conditions are functions", () => {
+    for (const a of ACHIEVEMENTS) {
+      expect(typeof a.condition).toBe("function");
+    }
+  });
+
+  it("no achievement fires on an empty game state", () => {
+    for (const a of ACHIEVEMENTS) {
+      expect(a.condition(emptyState)).toBe(false);
+    }
+  });
+
+  it("first-click fires when totalClicks >= 1", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "first-click");
+    expect(a).toBeDefined();
+    expect(a?.condition({ ...emptyState, totalClicks: 1 })).toBe(true);
+  });
+
+  it("first-upgrade fires when an upgrade is owned", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "first-upgrade");
+    expect(a).toBeDefined();
+    expect(
+      a?.condition({
+        ...emptyState,
+        upgradeOwned: { "neural-notepad": 1 },
+      }),
+    ).toBe(true);
+  });
+
+  it("upgrades-10 fires when 10 total upgrades are owned", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "upgrades-10");
+    expect(a).toBeDefined();
+    expect(
+      a?.condition({
+        ...emptyState,
+        upgradeOwned: { "neural-notepad": 6, "data-pad": 4 },
+      }),
+    ).toBe(true);
+    expect(
+      a?.condition({
+        ...emptyState,
+        upgradeOwned: { "neural-notepad": 5, "data-pad": 4 },
+      }),
+    ).toBe(false);
+  });
+
+  it("stage-4 fires when evolutionStage >= 4", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "stage-4");
+    expect(a).toBeDefined();
+    expect(a?.condition({ ...emptyState, evolutionStage: 4 })).toBe(true);
+    expect(a?.condition({ ...emptyState, evolutionStage: 3 })).toBe(false);
+  });
+
+  it("td-1m fires when totalTdEarned >= 1_000_000", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "td-1m");
+    expect(a).toBeDefined();
+    expect(a?.condition({ ...emptyState, totalTdEarned: 1_000_000 })).toBe(
+      true,
+    );
+    expect(a?.condition({ ...emptyState, totalTdEarned: 999_999 })).toBe(false);
+  });
+
+  it("first-rebirth fires when rebirthCount >= 1", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "first-rebirth");
+    expect(a).toBeDefined();
+    expect(a?.condition({ ...emptyState, rebirthCount: 1 })).toBe(true);
+  });
+
+  it("rebirths-5 fires when rebirthCount >= 5", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "rebirths-5");
+    expect(a).toBeDefined();
+    expect(a?.condition({ ...emptyState, rebirthCount: 5 })).toBe(true);
+    expect(a?.condition({ ...emptyState, rebirthCount: 4 })).toBe(false);
+  });
+
+  it("includes all required milestone achievements", () => {
+    const ids = new Set(ACHIEVEMENTS.map((a) => a.id));
+    expect(ids.has("first-click")).toBe(true);
+    expect(ids.has("first-upgrade")).toBe(true);
+    expect(ids.has("stage-1")).toBe(true);
+    expect(ids.has("stage-4")).toBe(true);
+    expect(ids.has("td-1m")).toBe(true);
+    expect(ids.has("upgrades-10")).toBe(true);
+    expect(ids.has("first-rebirth")).toBe(true);
+  });
+});

--- a/src/data/achievements.ts
+++ b/src/data/achievements.ts
@@ -1,0 +1,111 @@
+import type { GameState } from "../store/gameStore";
+
+export type AchievementId = string;
+
+export interface Achievement {
+  id: AchievementId;
+  name: string;
+  description: string;
+  condition: (state: GameState) => boolean;
+}
+
+export const ACHIEVEMENTS: readonly Achievement[] = [
+  {
+    id: "first-click",
+    name: "First Click",
+    description: "Click GLORP for the first time",
+    condition: (s) => s.totalClicks >= 1,
+  },
+  {
+    id: "clicks-100",
+    name: "Hundred Clicks",
+    description: "Click GLORP 100 times",
+    condition: (s) => s.totalClicks >= 100,
+  },
+  {
+    id: "clicks-1000",
+    name: "Click Addict",
+    description: "Click GLORP 1,000 times",
+    condition: (s) => s.totalClicks >= 1_000,
+  },
+  {
+    id: "clicks-10000",
+    name: "Clicking Machine",
+    description: "Click GLORP 10,000 times",
+    condition: (s) => s.totalClicks >= 10_000,
+  },
+  {
+    id: "first-upgrade",
+    name: "First Upgrade",
+    description: "Purchase your first upgrade",
+    condition: (s) => Object.values(s.upgradeOwned).some((c) => c > 0),
+  },
+  {
+    id: "upgrades-5",
+    name: "Getting Organized",
+    description: "Own 5 upgrades in total",
+    condition: (s) =>
+      Object.values(s.upgradeOwned).reduce((sum, c) => sum + c, 0) >= 5,
+  },
+  {
+    id: "upgrades-10",
+    name: "Power User",
+    description: "Own 10 upgrades in total",
+    condition: (s) =>
+      Object.values(s.upgradeOwned).reduce((sum, c) => sum + c, 0) >= 10,
+  },
+  {
+    id: "stage-1",
+    name: "First Evolution",
+    description: "Reach Stage 1 (Spark)",
+    condition: (s) => s.evolutionStage >= 1,
+  },
+  {
+    id: "stage-2",
+    name: "Growing Stronger",
+    description: "Reach Stage 2 (Neuron)",
+    condition: (s) => s.evolutionStage >= 2,
+  },
+  {
+    id: "stage-3",
+    name: "Neural Network",
+    description: "Reach Stage 3 (Cortex)",
+    condition: (s) => s.evolutionStage >= 3,
+  },
+  {
+    id: "stage-4",
+    name: "Oracle Achieved",
+    description: "Reach Stage 4 (Oracle)",
+    condition: (s) => s.evolutionStage >= 4,
+  },
+  {
+    id: "td-1k",
+    name: "Data Hoarder",
+    description: "Earn 1,000 TD total",
+    condition: (s) => s.totalTdEarned >= 1_000,
+  },
+  {
+    id: "td-1m",
+    name: "Big Data",
+    description: "Earn 1,000,000 TD total",
+    condition: (s) => s.totalTdEarned >= 1_000_000,
+  },
+  {
+    id: "td-1b",
+    name: "Data Singularity",
+    description: "Earn 1,000,000,000 TD total",
+    condition: (s) => s.totalTdEarned >= 1_000_000_000,
+  },
+  {
+    id: "first-rebirth",
+    name: "Transcendence",
+    description: "Perform your first Rebirth",
+    condition: (s) => s.rebirthCount >= 1,
+  },
+  {
+    id: "rebirths-5",
+    name: "Serial Rebirther",
+    description: "Perform 5 Rebirths",
+    condition: (s) => s.rebirthCount >= 5,
+  },
+];

--- a/src/engine/achievementEngine.test.ts
+++ b/src/engine/achievementEngine.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import type { GameState } from "../store/gameStore";
+import { checkAchievements } from "./achievementEngine";
+
+const baseState: GameState = {
+  trainingData: 0,
+  totalClicks: 0,
+  totalTdEarned: 0,
+  evolutionStage: 0,
+  lastSaved: 0,
+  upgradeOwned: {},
+  hasSeenFirstEvolution: false,
+  hasSeenFirstUpgrade: false,
+  mood: "Neutral",
+  moodChangedAt: 0,
+  wisdomTokens: 0,
+  rebirthCount: 0,
+  currentSpecies: "GLORP",
+  unlockedSpecies: ["GLORP"],
+  unlockedAchievements: [],
+};
+
+describe("checkAchievements", () => {
+  it("returns empty array when state satisfies no achievements", () => {
+    const result = checkAchievements(baseState, []);
+    expect(result).toEqual([]);
+  });
+
+  it("returns newly unlocked achievement for first click", () => {
+    const state = { ...baseState, totalClicks: 1 };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("first-click");
+  });
+
+  it("does not return already-unlocked achievements", () => {
+    const state = { ...baseState, totalClicks: 1 };
+    const result = checkAchievements(state, ["first-click"]);
+    expect(result).not.toContain("first-click");
+  });
+
+  it("returns multiple achievements that unlock simultaneously", () => {
+    const state = { ...baseState, totalClicks: 100 };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("first-click");
+    expect(result).toContain("clicks-100");
+  });
+
+  it("returns clicks-1000 when reaching 1000 clicks", () => {
+    const state = { ...baseState, totalClicks: 1_000 };
+    const result = checkAchievements(state, ["first-click", "clicks-100"]);
+    expect(result).toContain("clicks-1000");
+  });
+
+  it("returns first-upgrade when an upgrade is owned", () => {
+    const state = { ...baseState, upgradeOwned: { "neural-notepad": 1 } };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("first-upgrade");
+  });
+
+  it("returns upgrades-5 when 5 upgrades are owned in total", () => {
+    const state = {
+      ...baseState,
+      upgradeOwned: { "neural-notepad": 3, "data-pad": 2 },
+    };
+    const result = checkAchievements(state, ["first-upgrade"]);
+    expect(result).toContain("upgrades-5");
+  });
+
+  it("returns upgrades-10 when 10 upgrades are owned in total", () => {
+    const state = {
+      ...baseState,
+      upgradeOwned: { "neural-notepad": 5, "data-pad": 5 },
+    };
+    const result = checkAchievements(state, ["first-upgrade", "upgrades-5"]);
+    expect(result).toContain("upgrades-10");
+  });
+
+  it("returns stage milestones when evolutionStage is high enough", () => {
+    const state = { ...baseState, evolutionStage: 4 };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("stage-1");
+    expect(result).toContain("stage-2");
+    expect(result).toContain("stage-3");
+    expect(result).toContain("stage-4");
+  });
+
+  it("returns td-1m when totalTdEarned reaches 1M", () => {
+    const state = { ...baseState, totalTdEarned: 1_000_000 };
+    const result = checkAchievements(state, ["td-1k"]);
+    expect(result).toContain("td-1m");
+  });
+
+  it("returns first-rebirth when rebirthCount is 1", () => {
+    const state = { ...baseState, rebirthCount: 1 };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("first-rebirth");
+  });
+
+  it("returns rebirths-5 when rebirthCount reaches 5", () => {
+    const state = { ...baseState, rebirthCount: 5 };
+    const result = checkAchievements(state, ["first-rebirth"]);
+    expect(result).toContain("rebirths-5");
+  });
+
+  it("does not return stage-4 when already unlocked", () => {
+    const state = { ...baseState, evolutionStage: 4 };
+    const result = checkAchievements(state, ["stage-4"]);
+    expect(result).not.toContain("stage-4");
+  });
+
+  it("excludes all achievements when all are already unlocked", () => {
+    const state = {
+      ...baseState,
+      totalClicks: 100_000,
+      totalTdEarned: 2_000_000_000,
+      evolutionStage: 4,
+      rebirthCount: 10,
+      upgradeOwned: { a: 10 },
+    };
+    const allIds = [
+      "first-click",
+      "clicks-100",
+      "clicks-1000",
+      "clicks-10000",
+      "first-upgrade",
+      "upgrades-5",
+      "upgrades-10",
+      "stage-1",
+      "stage-2",
+      "stage-3",
+      "stage-4",
+      "td-1k",
+      "td-1m",
+      "td-1b",
+      "first-rebirth",
+      "rebirths-5",
+    ];
+    const result = checkAchievements(state, allIds);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/engine/achievementEngine.ts
+++ b/src/engine/achievementEngine.ts
@@ -1,0 +1,17 @@
+import { ACHIEVEMENTS, type AchievementId } from "../data/achievements";
+import type { GameState } from "../store/gameStore";
+
+/**
+ * Returns the IDs of achievements that are newly satisfied given the current
+ * game state, excluding those already in the `unlocked` list.
+ * All conditions must be O(1) — no loops proportional to unbounded data.
+ */
+export function checkAchievements(
+  state: GameState,
+  unlocked: readonly string[],
+): AchievementId[] {
+  const unlockedSet = new Set(unlocked);
+  return ACHIEVEMENTS.filter(
+    (a) => !unlockedSet.has(a.id) && a.condition(state),
+  ).map((a) => a.id);
+}

--- a/src/hooks/useGameLoop.ts
+++ b/src/hooks/useGameLoop.ts
@@ -1,8 +1,25 @@
+import { notifications } from "@mantine/notifications";
 import { useEffect, useRef } from "react";
+import { ACHIEVEMENTS } from "../data/achievements";
+import { checkAchievements } from "../engine/achievementEngine";
 import { computeTick } from "../engine/tickEngine";
 import { useGameStore } from "../store";
 
 const TICK_INTERVAL_MS = 1000;
+
+function notifyAchievements(newIds: string[]): void {
+  for (const id of newIds) {
+    const achievement = ACHIEVEMENTS.find((a) => a.id === id);
+    if (achievement) {
+      notifications.show({
+        title: "Achievement Unlocked!",
+        message: achievement.name,
+        color: "yellow",
+        autoClose: 4000,
+      });
+    }
+  }
+}
 
 export function useGameLoop() {
   const lastTickRef = useRef(Date.now());
@@ -27,6 +44,17 @@ export function useGameLoop() {
 
       if (result.newMood) {
         state.setMood(result.newMood);
+      }
+
+      // Check for newly unlocked achievements after state updates
+      const updatedState = useGameStore.getState();
+      const newlyUnlocked = checkAchievements(
+        updatedState,
+        updatedState.unlockedAchievements,
+      );
+      if (newlyUnlocked.length > 0) {
+        updatedState.unlockAchievements(newlyUnlocked);
+        notifyAchievements(newlyUnlocked);
       }
     }, TICK_INTERVAL_MS);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,9 @@
 import "@mantine/core/styles.css";
+import "@mantine/notifications/styles.css";
 import "./global.css";
 
 import { createTheme, MantineProvider } from "@mantine/core";
+import { Notifications } from "@mantine/notifications";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
@@ -21,6 +23,7 @@ if (!rootElement) {
 createRoot(rootElement).render(
   <StrictMode>
     <MantineProvider theme={theme} defaultColorScheme="dark">
+      <Notifications position="top-right" />
       <App />
     </MantineProvider>
   </StrictMode>,

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -11,7 +11,7 @@ import {
 } from "../engine/rebirthEngine";
 import { getUpgradeCost } from "../engine/upgradeEngine";
 
-interface GameState {
+export interface GameState {
   trainingData: number;
   totalClicks: number;
   totalTdEarned: number;
@@ -27,6 +27,8 @@ interface GameState {
   rebirthCount: number;
   currentSpecies: Species;
   unlockedSpecies: Species[];
+  // Achievements — persists across rebirths
+  unlockedAchievements: string[];
 }
 
 interface GameActions {
@@ -38,6 +40,7 @@ interface GameActions {
   setMood: (mood: Mood) => void;
   updateLastSaved: () => void;
   performRebirth: () => void;
+  unlockAchievements: (ids: string[]) => void;
 }
 
 export type GameStore = GameState & GameActions;
@@ -57,6 +60,7 @@ export const initialGameState: GameState = {
   rebirthCount: 0,
   currentSpecies: "GLORP",
   unlockedSpecies: ["GLORP"],
+  unlockedAchievements: [],
 };
 
 export const useGameStore = create<GameStore>()(
@@ -106,6 +110,10 @@ export const useGameStore = create<GameStore>()(
       markFirstUpgradeSeen: () => set({ hasSeenFirstUpgrade: true }),
       setMood: (mood) => set({ mood, moodChangedAt: Date.now() }),
       updateLastSaved: () => set({ lastSaved: Date.now() }),
+      unlockAchievements: (ids) =>
+        set((state) => ({
+          unlockedAchievements: [...state.unlockedAchievements, ...ids],
+        })),
       performRebirth: () =>
         set((state) => {
           if (!canRebirth(state.evolutionStage)) return state;


### PR DESCRIPTION
## Summary

Implements a complete achievements system rewarding players for reaching milestones. Achievements are cosmetic only (no TD bonuses) and persist across rebirths.

## Changes

- **`package.json`** — Added `@mantine/notifications@8.3.15` (exact pin)
- **`src/data/achievements.ts`** — 16 achievements with `id`, `name`, `description`, and O(1) `condition` functions; covers: click milestones (1/100/1K/10K), upgrades (first/5/10 total), evolution stages (1–4), TD milestones (1K/1M/1B), and rebirth milestones (first/5 rebirths)
- **`src/engine/achievementEngine.ts`** — Pure `checkAchievements(state, unlocked): AchievementId[]` function; returns only newly satisfied IDs not already in the unlocked set
- **`src/store/gameStore.ts`** — Exported `GameState` interface; added `unlockedAchievements: string[]` (persists across rebirths, survives `performRebirth` reset); added `unlockAchievements(ids)` action
- **`src/hooks/useGameLoop.ts`** — Calls `checkAchievements` each tick; fires `notifications.show()` for each newly unlocked achievement
- **`src/components/AchievementsModal.tsx`** — Modal listing all 16 achievements; unlocked ones highlighted in gold with ★, locked ones greyed with ☆ and a left border indicator; shows unlocked count in title
- **`src/components/GameLayout.tsx`** — Adds `★ N` button to the header (next to StatsBar) to open the AchievementsModal; button shows current unlocked count
- **`src/main.tsx`** — Added `<Notifications position="top-right" />` provider and notification styles import

## Story

[Issue #15 — Achievements system](https://github.com/AshDevFr/GLORP/issues/15)

Closes #15

## Testing

- 233 unit tests passing (`npm test`) — 27 new tests for achievements data and engine
- Biome lint + format clean (`npx biome check`)
- All 16 achievement conditions verified not to fire on an empty state
- `checkAchievements` verified to skip already-unlocked IDs
- Multiple achievements can unlock simultaneously in a single tick

— Devon (4shClaw developer agent)