### PR TITLE
feat: cross-generator synergies — depth over breadth (#44)

### DIFF
--- a/src/components/UpgradesPanel.tsx
+++ b/src/components/UpgradesPanel.tsx
@@ -148,6 +148,7 @@ export function UpgradesPanel() {
                     key={upgrade.id}
                     upgrade={upgrade}
                     owned={upgradeOwned[upgrade.id] ?? 0}
+                    allOwned={upgradeOwned}
                     trainingData={trainingData}
                     buyMode={buyMode}
                     onPurchase={purchaseBulkUpgrade}

--- a/src/components/upgrades/UpgradeCard.tsx
+++ b/src/components/upgrades/UpgradeCard.tsx
@@ -2,11 +2,13 @@ import { Badge, Button, Card, Group, Text } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { MILESTONE_THRESHOLDS } from "../../data/milestones";
+import { SYNERGIES } from "../../data/synergies";
 import type { Upgrade } from "../../data/upgrades";
 import {
   getMilestoneLevel,
   getMilestoneMultiplier,
 } from "../../engine/milestoneEngine";
+import { getSynergyMultiplier } from "../../engine/synergyEngine";
 import { getBulkCost, getMaxAffordable } from "../../engine/upgradeEngine";
 import { useReducedMotion } from "../../hooks/useReducedMotion";
 import type { BuyMode } from "../../store/settingsStore";
@@ -15,6 +17,7 @@ import { formatNumber } from "../../utils/formatNumber";
 interface UpgradeCardProps {
   upgrade: Upgrade;
   owned: number;
+  allOwned?: Record<string, number>;
   trainingData: number;
   buyMode: BuyMode;
   onPurchase: (id: string, count: number) => void;
@@ -23,6 +26,7 @@ interface UpgradeCardProps {
 export function UpgradeCard({
   upgrade,
   owned,
+  allOwned = {},
   trainingData,
   buyMode,
   onPurchase,
@@ -37,6 +41,7 @@ export function UpgradeCard({
   const milestoneLevel = getMilestoneLevel(owned);
   const milestoneMultiplier = getMilestoneMultiplier(owned);
   const nextThreshold = MILESTONE_THRESHOLDS[milestoneLevel];
+  const synergyMultiplier = getSynergyMultiplier(upgrade.id, allOwned);
 
   const [isGlowing, setIsGlowing] = useState(false);
   const [isMilestoneGlowing, setIsMilestoneGlowing] = useState(false);
@@ -46,10 +51,12 @@ export function UpgradeCard({
   const prevOwnedRef = useRef(owned);
   const prefersReduced = useReducedMotion();
 
-  // Detect milestone crossing and fire celebration
+  // Detect milestone crossing and synergy unlock; fire celebrations.
   useEffect(() => {
-    const prevLevel = getMilestoneLevel(prevOwnedRef.current);
+    const prev = prevOwnedRef.current;
+    const prevLevel = getMilestoneLevel(prev);
     const newLevel = getMilestoneLevel(owned);
+
     if (newLevel > prevLevel) {
       const threshold = MILESTONE_THRESHOLDS[newLevel - 1];
       notifications.show({
@@ -68,8 +75,25 @@ export function UpgradeCard({
         );
       }
     }
+
+    // Check synergy unlock (this generator is the source)
+    for (const synergy of SYNERGIES) {
+      if (
+        synergy.sourceId === upgrade.id &&
+        prev < synergy.threshold &&
+        owned >= synergy.threshold
+      ) {
+        notifications.show({
+          title: "⚡ Synergy unlocked!",
+          message: synergy.description,
+          color: "cyan",
+          autoClose: 5000,
+        });
+      }
+    }
+
     prevOwnedRef.current = owned;
-  }, [owned, upgrade.name, prefersReduced]);
+  }, [owned, upgrade.name, upgrade.id, prefersReduced]);
 
   const handlePurchase = useCallback(() => {
     onPurchase(upgrade.id, count);
@@ -88,6 +112,8 @@ export function UpgradeCard({
       : `${formatNumber(cost)} TD`;
 
   const isAnimating = isGlowing || isMilestoneGlowing;
+  const effectiveTdPerSecond =
+    upgrade.baseTdPerSecond * milestoneMultiplier * synergyMultiplier;
 
   return (
     <Card
@@ -139,11 +165,16 @@ export function UpgradeCard({
       <Group justify="space-between" align="center">
         <Group gap={4} align="center">
           <Text size="xs" ff="monospace" c="green">
-            +{formatNumber(upgrade.baseTdPerSecond * milestoneMultiplier)} TD/s
+            +{formatNumber(effectiveTdPerSecond)} TD/s
           </Text>
           {milestoneMultiplier > 1 && (
             <Badge size="xs" variant="light" color="yellow">
               ×{milestoneMultiplier}
+            </Badge>
+          )}
+          {synergyMultiplier > 1 && (
+            <Badge size="xs" variant="light" color="cyan">
+              ⚡×{synergyMultiplier}
             </Badge>
           )}
         </Group>

--- a/src/data/synergies.ts
+++ b/src/data/synergies.ts
@@ -1,0 +1,52 @@
+export interface Synergy {
+  sourceId: string;
+  threshold: number;
+  targetIds: string[];
+  bonusPercent: number;
+  description: string;
+}
+
+export const SYNERGIES: readonly Synergy[] = [
+  {
+    sourceId: "neural-notepad",
+    threshold: 50,
+    targetIds: ["neural-notepad", "data-hamster-wheel", "pattern-antenna"],
+    bonusPercent: 100,
+    description: "Neural Notepad ×50 boosts all Garage Lab generators!",
+  },
+  {
+    sourceId: "data-hamster-wheel",
+    threshold: 50,
+    targetIds: ["intern-algorithm"],
+    bonusPercent: 200,
+    description: "Data Hamster Wheel ×50 boosts Intern Algorithm!",
+  },
+  {
+    sourceId: "gpu-toaster",
+    threshold: 50,
+    targetIds: ["server-farm"],
+    bonusPercent: 150,
+    description: "GPU Toaster ×50 boosts Server Farm!",
+  },
+  {
+    sourceId: "server-farm",
+    threshold: 50,
+    targetIds: ["data-center"],
+    bonusPercent: 100,
+    description: "Server Farm ×50 boosts Data Center!",
+  },
+  {
+    sourceId: "ml-cluster",
+    threshold: 50,
+    targetIds: ["quantum-processor"],
+    bonusPercent: 100,
+    description: "ML Cluster ×50 boosts Quantum Processor!",
+  },
+  {
+    sourceId: "quantum-processor",
+    threshold: 50,
+    targetIds: ["mind-singularity"],
+    bonusPercent: 50,
+    description: "Quantum Processor ×50 boosts Mind Singularity!",
+  },
+];

--- a/src/engine/synergyEngine.test.ts
+++ b/src/engine/synergyEngine.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { getActiveSynergies, getSynergyMultiplier } from "./synergyEngine";
+
+describe("getActiveSynergies", () => {
+  it("returns empty when no generator is at threshold", () => {
+    expect(getActiveSynergies({})).toHaveLength(0);
+  });
+
+  it("returns empty when source is below threshold (49)", () => {
+    expect(getActiveSynergies({ "neural-notepad": 49 })).toHaveLength(0);
+  });
+
+  it("activates synergy at exactly the threshold (50)", () => {
+    const active = getActiveSynergies({ "neural-notepad": 50 });
+    expect(active).toHaveLength(1);
+    expect(active[0].sourceId).toBe("neural-notepad");
+  });
+
+  it("activates synergy beyond the threshold", () => {
+    const active = getActiveSynergies({ "neural-notepad": 100 });
+    expect(active).toHaveLength(1);
+    expect(active[0].sourceId).toBe("neural-notepad");
+  });
+
+  it("activates multiple synergies when multiple sources are at threshold", () => {
+    const active = getActiveSynergies({
+      "neural-notepad": 50,
+      "gpu-toaster": 50,
+    });
+    expect(active).toHaveLength(2);
+    const sourceIds = active.map((s) => s.sourceId);
+    expect(sourceIds).toContain("neural-notepad");
+    expect(sourceIds).toContain("gpu-toaster");
+  });
+
+  it("only activates synergies whose source meets the threshold", () => {
+    const active = getActiveSynergies({
+      "neural-notepad": 50,
+      "gpu-toaster": 49,
+    });
+    expect(active).toHaveLength(1);
+    expect(active[0].sourceId).toBe("neural-notepad");
+  });
+});
+
+describe("getSynergyMultiplier", () => {
+  it("returns 1 with no owned generators", () => {
+    expect(getSynergyMultiplier("neural-notepad", {})).toBe(1);
+  });
+
+  it("returns 1 when source is below threshold", () => {
+    expect(
+      getSynergyMultiplier("data-hamster-wheel", { "neural-notepad": 49 }),
+    ).toBe(1);
+  });
+
+  it("returns 2 (+100%) for garage-lab targets when neural-notepad reaches 50", () => {
+    const owned = { "neural-notepad": 50 };
+    expect(getSynergyMultiplier("neural-notepad", owned)).toBe(2);
+    expect(getSynergyMultiplier("data-hamster-wheel", owned)).toBe(2);
+    expect(getSynergyMultiplier("pattern-antenna", owned)).toBe(2);
+  });
+
+  it("returns 1 for non-target generators when neural-notepad reaches 50", () => {
+    const owned = { "neural-notepad": 50 };
+    expect(getSynergyMultiplier("intern-algorithm", owned)).toBe(1);
+    expect(getSynergyMultiplier("server-farm", owned)).toBe(1);
+  });
+
+  it("returns 3 (+200%) for intern-algorithm when data-hamster-wheel reaches 50", () => {
+    const owned = { "data-hamster-wheel": 50 };
+    expect(getSynergyMultiplier("intern-algorithm", owned)).toBe(3);
+  });
+
+  it("returns 2.5 (+150%) for server-farm when gpu-toaster reaches 50", () => {
+    const owned = { "gpu-toaster": 50 };
+    expect(getSynergyMultiplier("server-farm", owned)).toBe(2.5);
+  });
+
+  it("returns 2 (+100%) for data-center when server-farm reaches 50", () => {
+    const owned = { "server-farm": 50 };
+    expect(getSynergyMultiplier("data-center", owned)).toBe(2);
+  });
+
+  it("returns 2 (+100%) for quantum-processor when ml-cluster reaches 50", () => {
+    const owned = { "ml-cluster": 50 };
+    expect(getSynergyMultiplier("quantum-processor", owned)).toBe(2);
+  });
+
+  it("returns 1.5 (+50%) for mind-singularity when quantum-processor reaches 50", () => {
+    const owned = { "quantum-processor": 50 };
+    expect(getSynergyMultiplier("mind-singularity", owned)).toBe(1.5);
+  });
+
+  it("stacks multiplicatively when multiple synergies target the same generator", () => {
+    // neural-notepad at 50 → data-hamster-wheel +100% (×2)
+    // data-hamster-wheel at 50 → intern-algorithm +200% (×3)
+    // data-hamster-wheel receives from neural-notepad synergy only
+    const owned = { "neural-notepad": 50, "data-hamster-wheel": 50 };
+    // data-hamster-wheel: targeted by neural-notepad (+100%) → ×2
+    expect(getSynergyMultiplier("data-hamster-wheel", owned)).toBe(2);
+    // intern-algorithm: targeted by data-hamster-wheel (+200%) → ×3
+    expect(getSynergyMultiplier("intern-algorithm", owned)).toBe(3);
+  });
+});

--- a/src/engine/synergyEngine.ts
+++ b/src/engine/synergyEngine.ts
@@ -1,0 +1,24 @@
+import { SYNERGIES } from "../data/synergies";
+
+/**
+ * Returns the synergies that are currently active given owned generator counts.
+ */
+export function getActiveSynergies(
+  owned: Record<string, number>,
+): typeof SYNERGIES {
+  return SYNERGIES.filter((s) => (owned[s.sourceId] ?? 0) >= s.threshold);
+}
+
+/**
+ * Returns the total synergy multiplier for a generator.
+ * All active synergies whose targetIds include upgradeId stack multiplicatively.
+ * Returns 1 (no bonus) when no synergies apply.
+ */
+export function getSynergyMultiplier(
+  upgradeId: string,
+  owned: Record<string, number>,
+): number {
+  return getActiveSynergies(owned)
+    .filter((s) => s.targetIds.includes(upgradeId))
+    .reduce((acc, s) => acc * (1 + s.bonusPercent / 100), 1);
+}

--- a/src/engine/upgradeEngine.test.ts
+++ b/src/engine/upgradeEngine.test.ts
@@ -224,6 +224,64 @@ describe("getTotalTdPerSecond", () => {
       37.5,
     );
   });
+
+  it("applies no synergy for custom IDs not in the synergy map", () => {
+    // test-upgrade and test-upgrade-2 are not synergy sources or targets
+    const owned = { "test-upgrade": 50, "test-upgrade-2": 50 };
+    // milestone at 50 → ×3; no synergy; 50*1.5*3 + 50*5*3 = 225 + 750 = 975
+    expect(getTotalTdPerSecond([mockUpgrade, mockUpgrade2], owned)).toBeCloseTo(
+      975,
+    );
+  });
+});
+
+describe("getTotalTdPerSecond — synergy integration", () => {
+  const neuralNotepad: Upgrade = {
+    id: "neural-notepad",
+    name: "Neural Notepad",
+    description: "Test",
+    baseCost: 10,
+    baseTdPerSecond: 1,
+    tier: "garage-lab",
+    icon: "📝",
+    unlockStage: 0,
+  };
+
+  const patternAntenna: Upgrade = {
+    id: "pattern-antenna",
+    name: "Pattern Antenna",
+    description: "Test",
+    baseCost: 250,
+    baseTdPerSecond: 2,
+    tier: "garage-lab",
+    icon: "📡",
+    unlockStage: 0,
+  };
+
+  it("applies no synergy when source is below threshold", () => {
+    const owned = { "neural-notepad": 49, "pattern-antenna": 5 };
+    // neural-notepad: 49 owned → milestone ×2 (10 and 25 crossed), no synergy → 49*1*2=98
+    // pattern-antenna: 5 owned → milestone ×1, no synergy → 5*2*1=10
+    expect(
+      getTotalTdPerSecond([neuralNotepad, patternAntenna], owned),
+    ).toBeCloseTo(108);
+  });
+
+  it("applies +100% synergy to garage-lab generators when neural-notepad reaches 50", () => {
+    const owned = { "neural-notepad": 50, "pattern-antenna": 5 };
+    // neural-notepad: 50 owned → milestone ×3, synergy ×2 (target of itself) → 50*1*3*2=300
+    // pattern-antenna: 5 owned → milestone ×1, synergy ×2 → 5*2*1*2=20
+    expect(
+      getTotalTdPerSecond([neuralNotepad, patternAntenna], owned),
+    ).toBeCloseTo(320);
+  });
+
+  it("synergy multiplier stacks multiplicatively with milestone", () => {
+    // neural-notepad at 50: milestone ×3, synergy (self) ×2 → effective rate 1*3*2=6 per unit
+    const owned = { "neural-notepad": 50 };
+    // 50 * 1 * 3 * 2 = 300
+    expect(getTotalTdPerSecond([neuralNotepad], owned)).toBeCloseTo(300);
+  });
 });
 
 const mockBooster1: Booster = {

--- a/src/engine/upgradeEngine.ts
+++ b/src/engine/upgradeEngine.ts
@@ -1,6 +1,7 @@
 import type { Booster } from "../data/boosters";
 import type { Upgrade } from "../data/upgrades";
 import { getMilestoneMultiplier } from "./milestoneEngine";
+import { getSynergyMultiplier } from "./synergyEngine";
 
 export const COST_MULTIPLIER = 1.15;
 
@@ -59,7 +60,7 @@ export function computeBoosterMultiplier(
 
 /**
  * Returns the total TD/s from owned upgrades, applying per-generator milestone
- * multipliers, then the global wisdom and booster multipliers.
+ * and synergy multipliers, then the global wisdom and booster multipliers.
  * Defaults to no bonus (×1) for wisdom and booster multipliers.
  */
 export function getTotalTdPerSecond(
@@ -72,7 +73,9 @@ export function getTotalTdPerSecond(
   for (const upgrade of upgrades) {
     const count = owned[upgrade.id] ?? 0;
     const milestoneMultiplier = getMilestoneMultiplier(count);
-    total += upgrade.baseTdPerSecond * count * milestoneMultiplier;
+    const synergyMultiplier = getSynergyMultiplier(upgrade.id, owned);
+    total +=
+      upgrade.baseTdPerSecond * count * milestoneMultiplier * synergyMultiplier;
   }
   return total * wisdomMultiplier * boosterMultiplier;
 }


### PR DESCRIPTION
## Summary

Implements cross-generator synergies that unlock at 50 owned of a source generator and boost specific target generators, adding strategic depth to invest in one generator deeply.

## Changes

- **`src/data/synergies.ts`** (new): `Synergy` interface and `SYNERGIES` array with 6 synergy rules from the spec
- **`src/engine/synergyEngine.ts`** (new): `getActiveSynergies(owned)` and `getSynergyMultiplier(upgradeId, owned)` — active synergies stack multiplicatively
- **`src/engine/upgradeEngine.ts`**: `getTotalTdPerSecond` now applies synergy multiplier per-generator alongside the milestone multiplier
- **`src/components/upgrades/UpgradeCard.tsx`**: shows `⚡×N` synergy badge; fires "⚡ Synergy unlocked!" notification when the source generator crosses the threshold; `effectiveTdPerSecond` now incorporates synergy
- **`src/components/UpgradesPanel.tsx`**: passes `allOwned={upgradeOwned}` to each `UpgradeCard`
- **`src/engine/synergyEngine.test.ts`** (new): 16 tests covering `getActiveSynergies` and `getSynergyMultiplier`
- **`src/engine/upgradeEngine.test.ts`**: 4 new synergy integration tests

## Synergy Map

| Source (at 50 owned) | Target(s) | Bonus |
|---|---|---|
| Neural Notepad | All Garage Lab generators | +100% |
| Data Hamster Wheel | Intern Algorithm | +200% |
| GPU Toaster | Server Farm | +150% |
| Server Farm | Data Center | +100% |
| ML Cluster | Quantum Processor | +100% |
| Quantum Processor | Mind Singularity | +50% |

## Story

[[Phase 8] 8.3c Cross-generator synergies — depth over breadth](https://github.com/AshDevFr/GLORP/issues/44)

Closes #44

## Testing

- 411 tests passing, lint clean, build succeeds
- Verify: buy 50 of Neural Notepad → notification fires, all Garage Lab cards show ⚡×2 badge and doubled effective TD/s
- Synergies reset on rebirth (tied to `upgradeOwned` which resets)

— Devon (4shClaw developer agent)