### PR TITLE
feat: prestige shop & wisdom token rebalance

### DIFF
--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -1,6 +1,11 @@
 import { AppShell, Button, Grid, Group } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  getIdleBoostMultiplier,
+  getPrestigeOfflineEfficiency,
+} from "../data/prestigeShop";
+import { getSpeciesBonus } from "../data/species";
 import { EASTER_EGG_MESSAGES } from "../engine/easterEggEngine";
 import type { OfflineProgressResult } from "../engine/offlineEngine";
 import { computeOfflineProgress } from "../engine/offlineEngine";
@@ -32,7 +37,23 @@ export function GameLayout() {
 
   useEffect(() => {
     const state = useGameStore.getState();
-    const result = computeOfflineProgress(state.lastSaved, Date.now(), state);
+    const offlineEff = getPrestigeOfflineEfficiency(
+      state.prestigeUpgrades["offline-efficiency"] ?? 0,
+    );
+    const idleBoost = getIdleBoostMultiplier(
+      state.prestigeUpgrades["idle-boost"] ?? 0,
+    );
+    const speciesAutoGen = getSpeciesBonus(state.currentSpecies).autoGen;
+    const result = computeOfflineProgress(
+      state.lastSaved,
+      Date.now(),
+      {
+        ...state,
+        idleBoostMultiplier: idleBoost,
+        speciesAutoGenMultiplier: speciesAutoGen,
+      },
+      offlineEff,
+    );
     if (result) {
       state.addTrainingData(result.earned);
       setOfflineResult(result);

--- a/src/components/PetDisplay.tsx
+++ b/src/components/PetDisplay.tsx
@@ -2,6 +2,8 @@ import { Badge, Button, Group, Stack, Text } from "@mantine/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getAsciiArt } from "../data/asciiArt";
 import { CLICK_UPGRADES } from "../data/clickUpgrades";
+import { getClickMasteryBonus } from "../data/prestigeShop";
+import { getSpeciesBonus } from "../data/species";
 import { STAGES } from "../data/stages";
 import {
   COMBO_DECAY_MS,
@@ -17,6 +19,7 @@ import { useGameStore } from "../store";
 import { useUIStore } from "../store/uiStore";
 import { formatNumber } from "../utils/formatNumber";
 import { FloatingParticles } from "./FloatingParticles";
+import { PrestigeShop } from "./PrestigeShop";
 import { RebirthModal } from "./RebirthModal";
 import { SpeechBubble } from "./SpeechBubble";
 
@@ -35,11 +38,14 @@ export function PetDisplay() {
   const mood = useGameStore((s) => s.mood);
   const setMood = useGameStore((s) => s.setMood);
   const currentSpecies = useGameStore((s) => s.currentSpecies);
-  const wisdomTokens = useGameStore((s) => s.wisdomTokens);
   const totalTdEarned = useGameStore((s) => s.totalTdEarned);
   const performRebirth = useGameStore((s) => s.performRebirth);
   const clickUpgradesPurchased = useGameStore((s) => s.clickUpgradesPurchased);
   const comboCount = useGameStore((s) => s.comboCount);
+  const prestigeUpgrades = useGameStore((s) => s.prestigeUpgrades);
+  const prestigeTokenBalance = useGameStore((s) => s.prestigeTokenBalance);
+  const rebirthCount = useGameStore((s) => s.rebirthCount);
+  const unlockedSpecies = useGameStore((s) => s.unlockedSpecies);
 
   const art = getAsciiArt(currentSpecies, evolutionStage);
   const stageMeta = STAGES[evolutionStage] ?? STAGES[0];
@@ -47,6 +53,7 @@ export function PetDisplay() {
   const nextSpecies = getNextSpecies(currentSpecies);
 
   const [rebirthModalOpen, setRebirthModalOpen] = useState(false);
+  const [shopOpen, setShopOpen] = useState(false);
   const [displayCombo, setDisplayCombo] = useState(0);
 
   const dialogueLine = useDialogue();
@@ -88,6 +95,10 @@ export function PetDisplay() {
   // ────────────────────────────────────────────────────────────────────────
 
   // Compute current click power for display (without combo since it fluctuates)
+  const clickMastery = getClickMasteryBonus(
+    prestigeUpgrades["click-mastery"] ?? 0,
+  );
+  const speciesClickPower = getSpeciesBonus(currentSpecies).clickPower;
   const baseClickPower = computeClickPower(
     {
       evolutionStage,
@@ -97,6 +108,8 @@ export function PetDisplay() {
     },
     CLICK_UPGRADES,
     Date.now(),
+    clickMastery,
+    speciesClickPower,
   );
 
   // Decay combo display when not clicking
@@ -216,6 +229,17 @@ export function PetDisplay() {
               [ REBIRTH ]
             </Button>
           )}
+          {rebirthCount > 0 && (
+            <Button
+              size="lg"
+              variant="outline"
+              color="yellow"
+              onClick={() => setShopOpen(true)}
+              style={{ fontFamily: "monospace" }}
+            >
+              [ PRESTIGE SHOP ]
+            </Button>
+          )}
         </Group>
         {displayCombo >= COMBO_THRESHOLD && (
           <Badge
@@ -231,14 +255,19 @@ export function PetDisplay() {
       <RebirthModal
         opened={rebirthModalOpen}
         onClose={() => setRebirthModalOpen(false)}
-        onConfirm={() => {
-          performRebirth();
+        onConfirm={(selectedSpecies) => {
+          performRebirth(selectedSpecies);
           setRebirthModalOpen(false);
         }}
         totalTdEarned={totalTdEarned}
-        currentWisdomTokens={wisdomTokens}
+        currentBalance={prestigeTokenBalance}
         nextSpecies={nextSpecies}
+        currentSpecies={currentSpecies}
+        unlockedSpecies={unlockedSpecies}
+        hasUnlockAll={(prestigeUpgrades["unlock-all-species"] ?? 0) >= 1}
+        tokenMagnetLevel={prestigeUpgrades["token-magnet"] ?? 0}
       />
+      <PrestigeShop opened={shopOpen} onClose={() => setShopOpen(false)} />
     </div>
   );
 }

--- a/src/components/PrestigeShop.tsx
+++ b/src/components/PrestigeShop.tsx
@@ -1,0 +1,107 @@
+import {
+  Badge,
+  Button,
+  Card,
+  Group,
+  Modal,
+  ScrollArea,
+  Stack,
+  Text,
+  Title,
+} from "@mantine/core";
+import { PRESTIGE_UPGRADES } from "../data/prestigeShop";
+import { useGameStore } from "../store";
+
+interface PrestigeShopProps {
+  opened: boolean;
+  onClose: () => void;
+}
+
+export function PrestigeShop({ opened, onClose }: PrestigeShopProps) {
+  const prestigeTokenBalance = useGameStore((s) => s.prestigeTokenBalance);
+  const prestigeUpgrades = useGameStore((s) => s.prestigeUpgrades);
+  const purchasePrestigeUpgrade = useGameStore(
+    (s) => s.purchasePrestigeUpgrade,
+  );
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={
+        <Title order={4} ff="monospace" c="yellow">
+          Prestige Shop
+        </Title>
+      }
+      centered
+      size="lg"
+    >
+      <Stack gap="md">
+        <Text ta="center" size="sm" ff="monospace" c="yellow.4" fw={600}>
+          Wisdom Tokens:{" "}
+          <Text span fw={700}>
+            {prestigeTokenBalance} ✦
+          </Text>
+        </Text>
+
+        <ScrollArea.Autosize mah="60vh">
+          <Stack gap="xs">
+            {PRESTIGE_UPGRADES.map((upgrade) => {
+              const level = prestigeUpgrades[upgrade.id] ?? 0;
+              const maxed = level >= upgrade.maxLevel;
+              const canAfford =
+                !maxed && prestigeTokenBalance >= upgrade.costPerLevel;
+
+              return (
+                <Card
+                  key={upgrade.id}
+                  padding="sm"
+                  radius="sm"
+                  withBorder
+                  style={{
+                    borderColor: maxed
+                      ? "var(--mantine-color-yellow-8)"
+                      : canAfford
+                        ? "var(--mantine-color-green-8)"
+                        : "var(--mantine-color-dark-4)",
+                    opacity: maxed ? 0.7 : canAfford ? 1 : 0.5,
+                  }}
+                >
+                  <Group justify="space-between" mb={4}>
+                    <Text size="sm" fw={700} ff="monospace">
+                      {upgrade.icon} {upgrade.name}
+                    </Text>
+                    <Badge
+                      size="sm"
+                      variant="light"
+                      color={maxed ? "yellow" : "green"}
+                    >
+                      {level}/{upgrade.maxLevel}
+                    </Badge>
+                  </Group>
+
+                  <Text size="xs" c="dimmed" ff="monospace" mb={4}>
+                    {upgrade.description}
+                  </Text>
+
+                  <Group justify="flex-end">
+                    <Button
+                      size="compact-xs"
+                      variant={canAfford ? "filled" : "default"}
+                      color="yellow"
+                      disabled={!canAfford}
+                      onClick={() => purchasePrestigeUpgrade(upgrade.id)}
+                      ff="monospace"
+                    >
+                      {maxed ? "MAX" : `${upgrade.costPerLevel} ✦`}
+                    </Button>
+                  </Group>
+                </Card>
+              );
+            })}
+          </Stack>
+        </ScrollArea.Autosize>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/components/RebirthModal.tsx
+++ b/src/components/RebirthModal.tsx
@@ -1,18 +1,22 @@
-import { Button, Group, Modal, Stack, Text } from "@mantine/core";
+import { Button, Group, Modal, Select, Stack, Text } from "@mantine/core";
+import { useState } from "react";
+import { getTokenMagnetMultiplier } from "../data/prestigeShop";
 import type { Species } from "../data/species";
-import {
-  computeWisdomMultiplier,
-  computeWisdomTokens,
-} from "../engine/rebirthEngine";
+import { getSpeciesBonus } from "../data/species";
+import { computeWisdomTokens } from "../engine/rebirthEngine";
 import { formatNumber } from "../utils";
 
 interface RebirthModalProps {
   opened: boolean;
   onClose: () => void;
-  onConfirm: () => void;
+  onConfirm: (selectedSpecies?: Species) => void;
   totalTdEarned: number;
-  currentWisdomTokens: number;
+  currentBalance: number;
   nextSpecies: Species;
+  currentSpecies: Species;
+  unlockedSpecies: Species[];
+  hasUnlockAll: boolean;
+  tokenMagnetLevel: number;
 }
 
 export function RebirthModal({
@@ -20,12 +24,26 @@ export function RebirthModal({
   onClose,
   onConfirm,
   totalTdEarned,
-  currentWisdomTokens,
+  currentBalance,
   nextSpecies,
+  currentSpecies,
+  unlockedSpecies,
+  hasUnlockAll,
+  tokenMagnetLevel,
 }: RebirthModalProps) {
-  const tokensEarned = computeWisdomTokens(totalTdEarned);
-  const newTotal = currentWisdomTokens + tokensEarned;
-  const newMultiplier = computeWisdomMultiplier(newTotal);
+  const [selectedSpecies, setSelectedSpecies] = useState<Species | null>(null);
+
+  const tokenMagnet = getTokenMagnetMultiplier(tokenMagnetLevel);
+  const speciesWisdom = getSpeciesBonus(currentSpecies).wisdomBonus;
+  const tokensEarned = computeWisdomTokens(
+    totalTdEarned,
+    tokenMagnet * speciesWisdom,
+  );
+  const newBalance = currentBalance + tokensEarned;
+
+  const speciesChoices = hasUnlockAll ? unlockedSpecies : [nextSpecies];
+
+  const displaySpecies = selectedSpecies ?? nextSpecies;
 
   return (
     <Modal opened={opened} onClose={onClose} title="Rebirth" centered size="sm">
@@ -43,18 +61,37 @@ export function RebirthModal({
             </Text>
           </Text>
           <Text ta="center" size="sm" c="yellow.3">
-            Total after Rebirth:{" "}
+            Token balance after Rebirth:{" "}
             <Text span fw={700}>
-              {newTotal}
-            </Text>{" "}
-            ({((newMultiplier - 1) * 100).toFixed(0)}% TD/s bonus)
-          </Text>
-          <Text ta="center" size="sm" c="teal.4">
-            Next species unlocked:{" "}
-            <Text span fw={700} ff="monospace">
-              {nextSpecies}
+              {newBalance} ✦
             </Text>
           </Text>
+
+          {hasUnlockAll && speciesChoices.length > 1 ? (
+            <Stack gap={4} align="center">
+              <Text size="sm" c="teal.4">
+                Choose your species:
+              </Text>
+              <Select
+                data={speciesChoices.map((s) => ({
+                  value: s,
+                  label: s,
+                }))}
+                value={displaySpecies}
+                onChange={(val) => setSelectedSpecies((val as Species) ?? null)}
+                size="xs"
+                w={180}
+                ff="monospace"
+              />
+            </Stack>
+          ) : (
+            <Text ta="center" size="sm" c="teal.4">
+              Next species:{" "}
+              <Text span fw={700} ff="monospace">
+                {nextSpecies}
+              </Text>
+            </Text>
+          )}
         </Stack>
 
         <Text ta="center" size="xs" c="red.4">
@@ -66,7 +103,10 @@ export function RebirthModal({
           <Button variant="default" onClick={onClose}>
             Cancel
           </Button>
-          <Button color="yellow" onClick={onConfirm}>
+          <Button
+            color="yellow"
+            onClick={() => onConfirm(selectedSpecies ?? undefined)}
+          >
             Rebirth
           </Button>
         </Group>

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -1,8 +1,9 @@
 import { Group, Text } from "@mantine/core";
 import { useEffect, useRef, useState } from "react";
 import { BOOSTERS } from "../data/boosters";
+import { getIdleBoostMultiplier } from "../data/prestigeShop";
+import { getSpeciesBonus } from "../data/species";
 import { UPGRADES } from "../data/upgrades";
-import { computeWisdomMultiplier } from "../engine/rebirthEngine";
 import {
   computeBoosterMultiplier,
   getTotalTdPerSecond,
@@ -17,9 +18,13 @@ const RATE_BOOST_DURATION_MS = 3000;
 export function StatsBar() {
   const trainingData = useInterpolatedTd();
   const upgradeOwned = useGameStore((s) => s.upgradeOwned);
-  const wisdomTokens = useGameStore((s) => s.wisdomTokens);
+  const prestigeTokenBalance = useGameStore((s) => s.prestigeTokenBalance);
   const boostersPurchased = useGameStore((s) => s.boostersPurchased);
-  const wisdomMultiplier = computeWisdomMultiplier(wisdomTokens);
+  const prestigeUpgrades = useGameStore((s) => s.prestigeUpgrades);
+  const currentSpecies = useGameStore((s) => s.currentSpecies);
+  const rebirthCount = useGameStore((s) => s.rebirthCount);
+  const idleBoost = getIdleBoostMultiplier(prestigeUpgrades["idle-boost"] ?? 0);
+  const speciesAutoGen = getSpeciesBonus(currentSpecies).autoGen;
   const boosterMultiplier = computeBoosterMultiplier(
     BOOSTERS,
     boostersPurchased,
@@ -27,7 +32,7 @@ export function StatsBar() {
   const tdPerSecond = getTotalTdPerSecond(
     UPGRADES,
     upgradeOwned,
-    wisdomMultiplier,
+    idleBoost * speciesAutoGen,
     boosterMultiplier,
   );
   const numberFormat = useSettingsStore((s) => s.numberFormat);
@@ -85,11 +90,11 @@ export function StatsBar() {
           </Text>
         )}
       </Text>
-      {wisdomTokens > 0 && (
+      {rebirthCount > 0 && (
         <Text size="sm" ff="monospace">
           Wisdom:{" "}
           <Text span fw={700} c="yellow">
-            {wisdomTokens} ✦ (+{((wisdomMultiplier - 1) * 100).toFixed(0)}%)
+            {prestigeTokenBalance} ✦
           </Text>
         </Text>
       )}

--- a/src/components/UpgradesPanel.tsx
+++ b/src/components/UpgradesPanel.tsx
@@ -10,6 +10,7 @@ import {
 import { useEffect } from "react";
 import { BOOSTERS } from "../data/boosters";
 import { CLICK_UPGRADES } from "../data/clickUpgrades";
+import { getGeneratorCostMultiplier } from "../data/prestigeShop";
 import type { Upgrade } from "../data/upgrades";
 import { UPGRADES } from "../data/upgrades";
 import { useGameStore } from "../store";
@@ -50,6 +51,10 @@ export function UpgradesPanel() {
   const evolutionStage = useGameStore((s) => s.evolutionStage);
   const clickUpgradesPurchased = useGameStore((s) => s.clickUpgradesPurchased);
   const boostersPurchased = useGameStore((s) => s.boostersPurchased);
+  const prestigeUpgrades = useGameStore((s) => s.prestigeUpgrades);
+  const costMultiplier = getGeneratorCostMultiplier(
+    prestigeUpgrades["generator-discount"] ?? 0,
+  );
 
   const buyMode = useSettingsStore((s) => s.buyMode);
   const setBuyMode = useSettingsStore((s) => s.setBuyMode);
@@ -152,6 +157,7 @@ export function UpgradesPanel() {
                     trainingData={trainingData}
                     buyMode={buyMode}
                     onPurchase={purchaseBulkUpgrade}
+                    costMultiplier={costMultiplier}
                   />
                 ))}
               </div>

--- a/src/components/upgrades/UpgradeCard.tsx
+++ b/src/components/upgrades/UpgradeCard.tsx
@@ -21,6 +21,7 @@ interface UpgradeCardProps {
   trainingData: number;
   buyMode: BuyMode;
   onPurchase: (id: string, count: number) => void;
+  costMultiplier?: number;
 }
 
 export function UpgradeCard({
@@ -30,12 +31,13 @@ export function UpgradeCard({
   trainingData,
   buyMode,
   onPurchase,
+  costMultiplier,
 }: UpgradeCardProps) {
   const count =
     buyMode === "max"
-      ? getMaxAffordable(upgrade, owned, trainingData)
+      ? getMaxAffordable(upgrade, owned, trainingData, costMultiplier)
       : buyMode;
-  const cost = getBulkCost(upgrade, owned, count);
+  const cost = getBulkCost(upgrade, owned, count, costMultiplier);
   const canAfford = count > 0 && trainingData >= cost;
 
   const milestoneLevel = getMilestoneLevel(owned);

--- a/src/data/achievements.test.ts
+++ b/src/data/achievements.test.ts
@@ -25,6 +25,8 @@ const emptyState: GameState = {
   comboCount: 0,
   lastClickTime: 0,
   crossedMilestones: [],
+  prestigeUpgrades: {},
+  prestigeTokenBalance: 0,
 };
 
 describe("ACHIEVEMENTS", () => {

--- a/src/data/prestigeShop.test.ts
+++ b/src/data/prestigeShop.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  getClickMasteryBonus,
+  getEvolutionThresholdMultiplier,
+  getGeneratorCostMultiplier,
+  getIdleBoostMultiplier,
+  getPrestigeCost,
+  getPrestigeOfflineEfficiency,
+  getQuickStartTd,
+  getRetainedTiers,
+  getTokenMagnetMultiplier,
+  PRESTIGE_UPGRADES,
+} from "./prestigeShop";
+
+describe("PRESTIGE_UPGRADES data", () => {
+  it("defines 10 upgrades", () => {
+    expect(PRESTIGE_UPGRADES).toHaveLength(10);
+  });
+
+  it("all upgrades have unique IDs", () => {
+    const ids = PRESTIGE_UPGRADES.map((u) => u.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("all upgrades have positive costPerLevel and maxLevel", () => {
+    for (const u of PRESTIGE_UPGRADES) {
+      expect(u.costPerLevel).toBeGreaterThan(0);
+      expect(u.maxLevel).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("getPrestigeCost", () => {
+  it("returns costPerLevel", () => {
+    const upgrade = PRESTIGE_UPGRADES[0];
+    expect(getPrestigeCost(upgrade)).toBe(upgrade.costPerLevel);
+  });
+});
+
+describe("getQuickStartTd", () => {
+  it("returns 0 at level 0", () => {
+    expect(getQuickStartTd(0)).toBe(0);
+  });
+
+  it("returns 1,000 at level 1", () => {
+    expect(getQuickStartTd(1)).toBe(1_000);
+  });
+
+  it("returns 10,000 at level 2", () => {
+    expect(getQuickStartTd(2)).toBe(10_000);
+  });
+
+  it("returns 100,000 at level 3", () => {
+    expect(getQuickStartTd(3)).toBe(100_000);
+  });
+});
+
+describe("getGeneratorCostMultiplier", () => {
+  it("returns 1.15 at level 0 (default)", () => {
+    expect(getGeneratorCostMultiplier(0)).toBeCloseTo(1.15);
+  });
+
+  it("returns 1.14 at level 1", () => {
+    expect(getGeneratorCostMultiplier(1)).toBeCloseTo(1.14);
+  });
+
+  it("returns 1.12 at level 3", () => {
+    expect(getGeneratorCostMultiplier(3)).toBeCloseTo(1.12);
+  });
+});
+
+describe("getIdleBoostMultiplier", () => {
+  it("returns 1 at level 0 (no bonus)", () => {
+    expect(getIdleBoostMultiplier(0)).toBe(1);
+  });
+
+  it("returns 1.25 at level 1", () => {
+    expect(getIdleBoostMultiplier(1)).toBeCloseTo(1.25);
+  });
+
+  it("returns 2.25 at level 5", () => {
+    expect(getIdleBoostMultiplier(5)).toBeCloseTo(2.25);
+  });
+});
+
+describe("getPrestigeOfflineEfficiency", () => {
+  it("returns 0.5 at level 0 (default)", () => {
+    expect(getPrestigeOfflineEfficiency(0)).toBeCloseTo(0.5);
+  });
+
+  it("returns 0.6 at level 1", () => {
+    expect(getPrestigeOfflineEfficiency(1)).toBeCloseTo(0.6);
+  });
+
+  it("returns 0.8 at level 3", () => {
+    expect(getPrestigeOfflineEfficiency(3)).toBeCloseTo(0.8);
+  });
+});
+
+describe("getEvolutionThresholdMultiplier", () => {
+  it("returns 1 at level 0 (no reduction)", () => {
+    expect(getEvolutionThresholdMultiplier(0)).toBe(1);
+  });
+
+  it("returns 0.9 at level 1", () => {
+    expect(getEvolutionThresholdMultiplier(1)).toBeCloseTo(0.9);
+  });
+
+  it("returns 0.7 at level 3", () => {
+    expect(getEvolutionThresholdMultiplier(3)).toBeCloseTo(0.7);
+  });
+});
+
+describe("getClickMasteryBonus", () => {
+  it("returns 0 at level 0", () => {
+    expect(getClickMasteryBonus(0)).toBe(0);
+  });
+
+  it("returns level value", () => {
+    expect(getClickMasteryBonus(5)).toBe(5);
+  });
+});
+
+describe("getTokenMagnetMultiplier", () => {
+  it("returns 1 at level 0 (no bonus)", () => {
+    expect(getTokenMagnetMultiplier(0)).toBe(1);
+  });
+
+  it("returns 1.2 at level 1", () => {
+    expect(getTokenMagnetMultiplier(1)).toBeCloseTo(1.2);
+  });
+
+  it("returns 2 at level 5", () => {
+    expect(getTokenMagnetMultiplier(5)).toBeCloseTo(2);
+  });
+});
+
+describe("getRetainedTiers", () => {
+  it("returns empty at level 0", () => {
+    expect(getRetainedTiers(0)).toEqual([]);
+  });
+
+  it("returns first tier at level 1", () => {
+    expect(getRetainedTiers(1)).toEqual(["garage-lab"]);
+  });
+
+  it("returns first 3 tiers at level 3", () => {
+    expect(getRetainedTiers(3)).toEqual(["garage-lab", "startup", "scale-up"]);
+  });
+
+  it("returns all 5 tiers at level 5", () => {
+    expect(getRetainedTiers(5)).toEqual([
+      "garage-lab",
+      "startup",
+      "scale-up",
+      "mega-corp",
+      "transcendence",
+    ]);
+  });
+});

--- a/src/data/prestigeShop.ts
+++ b/src/data/prestigeShop.ts
@@ -1,0 +1,146 @@
+export interface PrestigeUpgrade {
+  id: string;
+  name: string;
+  description: string;
+  costPerLevel: number;
+  maxLevel: number;
+  icon: string;
+}
+
+export const PRESTIGE_UPGRADES: readonly PrestigeUpgrade[] = [
+  {
+    id: "quick-start",
+    name: "Quick Start",
+    description: "Start runs with bonus TD",
+    costPerLevel: 5,
+    maxLevel: 3,
+    icon: "🚀",
+  },
+  {
+    id: "auto-buy",
+    name: "Auto-Buy",
+    description: "Auto-buy cheapest affordable generator each tick",
+    costPerLevel: 10,
+    maxLevel: 1,
+    icon: "🤖",
+  },
+  {
+    id: "click-mastery",
+    name: "Click Mastery",
+    description: "+1x base click power per level",
+    costPerLevel: 3,
+    maxLevel: 10,
+    icon: "👆",
+  },
+  {
+    id: "generator-discount",
+    name: "Generator Discount",
+    description: "Reduce generator cost multiplier",
+    costPerLevel: 8,
+    maxLevel: 3,
+    icon: "💰",
+  },
+  {
+    id: "idle-boost",
+    name: "Idle Boost",
+    description: "+25% all auto-gen TD/s per level",
+    costPerLevel: 5,
+    maxLevel: 5,
+    icon: "⏱️",
+  },
+  {
+    id: "offline-efficiency",
+    name: "Offline Efficiency",
+    description: "Increase offline earning rate",
+    costPerLevel: 5,
+    maxLevel: 3,
+    icon: "🌙",
+  },
+  {
+    id: "evolution-accelerator",
+    name: "Evolution Accelerator",
+    description: "Evolution thresholds −10% per level",
+    costPerLevel: 15,
+    maxLevel: 3,
+    icon: "⚡",
+  },
+  {
+    id: "species-memory",
+    name: "Species Memory",
+    description: "Keep one tier's generators across rebirth per level",
+    costPerLevel: 20,
+    maxLevel: 5,
+    icon: "🧬",
+  },
+  {
+    id: "token-magnet",
+    name: "Token Magnet",
+    description: "+20% Wisdom Tokens earned on rebirth per level",
+    costPerLevel: 10,
+    maxLevel: 5,
+    icon: "🧲",
+  },
+  {
+    id: "unlock-all-species",
+    name: "Unlock All Species",
+    description: "Choose any species on rebirth",
+    costPerLevel: 50,
+    maxLevel: 1,
+    icon: "🌟",
+  },
+];
+
+/** Generator tiers in order, matching Upgrade.tier values. */
+const TIER_ORDER: readonly string[] = [
+  "garage-lab",
+  "startup",
+  "scale-up",
+  "mega-corp",
+  "transcendence",
+];
+
+/** Returns the cost for the next level of a prestige upgrade. */
+export function getPrestigeCost(upgrade: PrestigeUpgrade): number {
+  return upgrade.costPerLevel;
+}
+
+/** Starting TD from the Quick Start prestige upgrade. */
+export function getQuickStartTd(level: number): number {
+  const amounts = [0, 1_000, 10_000, 100_000];
+  return amounts[Math.min(level, amounts.length - 1)];
+}
+
+/** Cost multiplier (replaces base 1.15) based on Generator Discount level. */
+export function getGeneratorCostMultiplier(level: number): number {
+  return 1.15 - level * 0.01;
+}
+
+/** Idle Boost multiplier for auto-gen TD/s. */
+export function getIdleBoostMultiplier(level: number): number {
+  return 1 + level * 0.25;
+}
+
+/** Offline efficiency (replaces base 0.5) based on Offline Efficiency level. */
+export function getPrestigeOfflineEfficiency(level: number): number {
+  return 0.5 + level * 0.1;
+}
+
+/** Evolution threshold multiplier based on Evolution Accelerator level. */
+export function getEvolutionThresholdMultiplier(level: number): number {
+  return 1 - level * 0.1;
+}
+
+/** Extra base click power from Click Mastery. */
+export function getClickMasteryBonus(level: number): number {
+  return level;
+}
+
+/** Token Magnet multiplier applied to WT earned on rebirth. */
+export function getTokenMagnetMultiplier(level: number): number {
+  return 1 + level * 0.2;
+}
+
+/** Returns tiers retained across rebirth by Species Memory level. */
+export function getRetainedTiers(level: number): readonly string[] {
+  return TIER_ORDER.slice(0, level);
+}

--- a/src/data/species.test.ts
+++ b/src/data/species.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { getSpeciesBonus, SPECIES_ORDER } from "./species";
+
+describe("SPECIES_ORDER", () => {
+  it("has 5 species", () => {
+    expect(SPECIES_ORDER).toHaveLength(5);
+  });
+
+  it("starts with GLORP", () => {
+    expect(SPECIES_ORDER[0]).toBe("GLORP");
+  });
+
+  it("ends with MEGA-GLORP", () => {
+    expect(SPECIES_ORDER[SPECIES_ORDER.length - 1]).toBe("MEGA-GLORP");
+  });
+});
+
+describe("getSpeciesBonus", () => {
+  it("GLORP has no bonuses (all 1.0)", () => {
+    const bonus = getSpeciesBonus("GLORP");
+    expect(bonus.autoGen).toBe(1.0);
+    expect(bonus.clickPower).toBe(1.0);
+    expect(bonus.wisdomBonus).toBe(1.0);
+  });
+
+  it("ZAPPY has +25% auto-gen", () => {
+    const bonus = getSpeciesBonus("ZAPPY");
+    expect(bonus.autoGen).toBe(1.25);
+    expect(bonus.clickPower).toBe(1.0);
+    expect(bonus.wisdomBonus).toBe(1.0);
+  });
+
+  it("CHONK has +50% click power", () => {
+    const bonus = getSpeciesBonus("CHONK");
+    expect(bonus.autoGen).toBe(1.0);
+    expect(bonus.clickPower).toBe(1.5);
+    expect(bonus.wisdomBonus).toBe(1.0);
+  });
+
+  it("WISP has +25% wisdom bonus", () => {
+    const bonus = getSpeciesBonus("WISP");
+    expect(bonus.autoGen).toBe(1.0);
+    expect(bonus.clickPower).toBe(1.0);
+    expect(bonus.wisdomBonus).toBe(1.25);
+  });
+
+  it("MEGA-GLORP has +10% in all categories", () => {
+    const bonus = getSpeciesBonus("MEGA-GLORP");
+    expect(bonus.autoGen).toBeCloseTo(1.1);
+    expect(bonus.clickPower).toBeCloseTo(1.1);
+    expect(bonus.wisdomBonus).toBeCloseTo(1.1);
+  });
+});

--- a/src/data/species.ts
+++ b/src/data/species.ts
@@ -1,5 +1,11 @@
 export type Species = "GLORP" | "ZAPPY" | "CHONK" | "WISP" | "MEGA-GLORP";
 
+export interface SpeciesBonus {
+  autoGen: number;
+  clickPower: number;
+  wisdomBonus: number;
+}
+
 export const SPECIES_ORDER: readonly Species[] = [
   "GLORP",
   "ZAPPY",
@@ -7,3 +13,15 @@ export const SPECIES_ORDER: readonly Species[] = [
   "WISP",
   "MEGA-GLORP",
 ];
+
+const SPECIES_BONUSES: Readonly<Record<Species, SpeciesBonus>> = {
+  GLORP: { autoGen: 1.0, clickPower: 1.0, wisdomBonus: 1.0 },
+  ZAPPY: { autoGen: 1.25, clickPower: 1.0, wisdomBonus: 1.0 },
+  CHONK: { autoGen: 1.0, clickPower: 1.5, wisdomBonus: 1.0 },
+  WISP: { autoGen: 1.0, clickPower: 1.0, wisdomBonus: 1.25 },
+  "MEGA-GLORP": { autoGen: 1.1, clickPower: 1.1, wisdomBonus: 1.1 },
+};
+
+export function getSpeciesBonus(species: Species): SpeciesBonus {
+  return SPECIES_BONUSES[species];
+}

--- a/src/engine/achievementEngine.test.ts
+++ b/src/engine/achievementEngine.test.ts
@@ -25,6 +25,8 @@ const baseState: GameState = {
   comboCount: 0,
   lastClickTime: 0,
   crossedMilestones: [],
+  prestigeUpgrades: {},
+  prestigeTokenBalance: 0,
 };
 
 describe("checkAchievements", () => {

--- a/src/engine/clickEngine.ts
+++ b/src/engine/clickEngine.ts
@@ -22,14 +22,18 @@ interface ClickPowerState {
 /**
  * Compute the total click power.
  *
- * Formula: (1 + evolutionStage) × product(purchased upgrade multipliers) × comboMultiplier
+ * Formula: (1 + evolutionStage + clickMasteryBonus)
+ *          × product(purchased upgrade multipliers)
+ *          × comboMultiplier × speciesClickMultiplier
  */
 export function computeClickPower(
   state: ClickPowerState,
   clickUpgrades: readonly ClickUpgrade[],
   now?: number,
+  clickMasteryBonus = 0,
+  speciesClickMultiplier = 1,
 ): number {
-  const base = 1 + state.evolutionStage;
+  const base = 1 + state.evolutionStage + clickMasteryBonus;
 
   let upgradeMultiplier = 1;
   for (const upgrade of clickUpgrades) {
@@ -44,7 +48,7 @@ export function computeClickPower(
     now,
   );
 
-  return base * upgradeMultiplier * combo;
+  return base * upgradeMultiplier * combo * speciesClickMultiplier;
 }
 
 /**

--- a/src/engine/evolutionEngine.ts
+++ b/src/engine/evolutionEngine.ts
@@ -1,9 +1,17 @@
 import { STAGES } from "../data/stages";
 
-export function getEvolutionStage(totalTdEarned: number): number {
+/**
+ * Returns the evolution stage for a given total TD earned.
+ * `thresholdMultiplier` scales unlock thresholds (Evolution Accelerator prestige).
+ * A multiplier < 1 makes stages unlock earlier.
+ */
+export function getEvolutionStage(
+  totalTdEarned: number,
+  thresholdMultiplier = 1,
+): number {
   let stage = 0;
   for (const s of STAGES) {
-    if (totalTdEarned >= s.unlockAt) {
+    if (totalTdEarned >= s.unlockAt * thresholdMultiplier) {
       stage = s.stage;
     }
   }

--- a/src/engine/offlineEngine.ts
+++ b/src/engine/offlineEngine.ts
@@ -10,7 +10,9 @@ interface OfflineState {
   mood: Mood;
   moodChangedAt: number;
   evolutionStage: number;
-  wisdomTokens?: number;
+  boostersPurchased?: string[];
+  idleBoostMultiplier?: number;
+  speciesAutoGenMultiplier?: number;
 }
 
 export interface OfflineProgressResult {
@@ -24,11 +26,13 @@ export interface OfflineProgressResult {
  * Compute offline Training Data earned since lastSaved.
  * Returns null if below the 5-minute threshold or if nothing was earned.
  * Reuses computeTick for TD calculation logic.
+ * `offlineEfficiency` overrides the default 50% rate (prestige upgrade).
  */
 export function computeOfflineProgress(
   lastSaved: number,
   now: number,
   state: OfflineState,
+  offlineEfficiency = OFFLINE_EFFICIENCY,
 ): OfflineProgressResult | null {
   if (lastSaved === 0) return null;
 
@@ -42,7 +46,7 @@ export function computeOfflineProgress(
 
   // Reuse computeTick for TD calculation (no duplicated TD/s logic)
   const tickResult = computeTick(state, cappedSeconds, now);
-  const earned = tickResult.trainingDataDelta * OFFLINE_EFFICIENCY;
+  const earned = tickResult.trainingDataDelta * offlineEfficiency;
 
   if (earned === 0) return null;
 

--- a/src/engine/rebirthEngine.test.ts
+++ b/src/engine/rebirthEngine.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   canRebirth,
-  computeWisdomMultiplier,
   computeWisdomTokens,
   getNextSpecies,
   REBIRTH_MIN_STAGE,
-  WISDOM_MULTIPLIER_PER_TOKEN,
   WISDOM_TOKENS_DIVISOR,
 } from "./rebirthEngine";
 
@@ -14,62 +12,57 @@ describe("computeWisdomTokens", () => {
     expect(computeWisdomTokens(0)).toBe(0);
   });
 
-  it("returns 0 below 1M TD (sqrt < 1)", () => {
-    expect(computeWisdomTokens(999_999)).toBe(0);
+  it("returns 0 below 100K TD (sqrt < 1)", () => {
+    expect(computeWisdomTokens(99_999)).toBe(0);
   });
 
-  it("returns 1 at exactly 1M TD", () => {
-    // floor(sqrt(1_000_000 / 1_000_000)) = floor(sqrt(1)) = 1
+  it("returns 1 at exactly 100K TD", () => {
+    // floor(sqrt(100_000 / 100_000)) = floor(sqrt(1)) = 1
     expect(computeWisdomTokens(WISDOM_TOKENS_DIVISOR)).toBe(1);
   });
 
-  it("returns correct tokens for 4M TD", () => {
-    // floor(sqrt(4_000_000 / 1_000_000)) = floor(sqrt(4)) = floor(2) = 2
-    expect(computeWisdomTokens(4_000_000)).toBe(2);
+  it("returns correct tokens for 400K TD", () => {
+    // floor(sqrt(400_000 / 100_000)) = floor(sqrt(4)) = 2
+    expect(computeWisdomTokens(400_000)).toBe(2);
   });
 
-  it("returns correct tokens for 9M TD", () => {
+  it("returns correct tokens for 900K TD", () => {
     // floor(sqrt(9)) = 3
-    expect(computeWisdomTokens(9_000_000)).toBe(3);
+    expect(computeWisdomTokens(900_000)).toBe(3);
   });
 
-  it("returns correct tokens for 10M TD (stage 4 unlock threshold)", () => {
-    // floor(sqrt(10)) ≈ floor(3.162) = 3
-    expect(computeWisdomTokens(10_000_000)).toBe(3);
+  it("returns correct tokens for 1M TD", () => {
+    // floor(sqrt(1_000_000 / 100_000)) = floor(sqrt(10)) ≈ floor(3.162) = 3
+    expect(computeWisdomTokens(1_000_000)).toBe(3);
   });
 
   it("floors fractional results", () => {
-    // floor(sqrt(2_000_000 / 1_000_000)) = floor(sqrt(2)) = floor(1.414) = 1
-    expect(computeWisdomTokens(2_000_000)).toBe(1);
+    // floor(sqrt(200_000 / 100_000)) = floor(sqrt(2)) = floor(1.414) = 1
+    expect(computeWisdomTokens(200_000)).toBe(1);
   });
 
-  it("scales correctly at 100M TD", () => {
-    // floor(sqrt(100)) = 10
-    expect(computeWisdomTokens(100_000_000)).toBe(10);
-  });
-});
-
-describe("computeWisdomMultiplier", () => {
-  it("returns 1.0 with 0 tokens (no bonus)", () => {
-    expect(computeWisdomMultiplier(0)).toBeCloseTo(1.0);
+  it("scales correctly at 10M TD", () => {
+    // floor(sqrt(10_000_000 / 100_000)) = floor(sqrt(100)) = 10
+    expect(computeWisdomTokens(10_000_000)).toBe(10);
   });
 
-  it("returns 1.05 with 1 token (5% bonus)", () => {
-    expect(computeWisdomMultiplier(1)).toBeCloseTo(
-      1 + WISDOM_MULTIPLIER_PER_TOKEN,
-    );
+  it("applies tokenMagnetMultiplier", () => {
+    // base = floor(sqrt(400_000 / 100_000)) = 2, then floor(2 * 1.5) = 3
+    expect(computeWisdomTokens(400_000, 1.5)).toBe(3);
   });
 
-  it("returns 1.1 with 2 tokens (10% bonus)", () => {
-    expect(computeWisdomMultiplier(2)).toBeCloseTo(1.1);
+  it("floors result after tokenMagnetMultiplier", () => {
+    // base = floor(sqrt(100_000 / 100_000)) = 1, then floor(1 * 1.2) = 1
+    expect(computeWisdomTokens(100_000, 1.2)).toBe(1);
   });
 
-  it("returns 1.5 with 10 tokens (50% bonus)", () => {
-    expect(computeWisdomMultiplier(10)).toBeCloseTo(1.5);
+  it("tokenMagnetMultiplier of 2 doubles tokens", () => {
+    // base = floor(sqrt(900_000 / 100_000)) = 3, then floor(3 * 2) = 6
+    expect(computeWisdomTokens(900_000, 2)).toBe(6);
   });
 
-  it("scales linearly with token count", () => {
-    expect(computeWisdomMultiplier(20)).toBeCloseTo(2.0);
+  it("defaults tokenMagnetMultiplier to 1", () => {
+    expect(computeWisdomTokens(400_000)).toBe(computeWisdomTokens(400_000, 1));
   });
 });
 

--- a/src/engine/rebirthEngine.ts
+++ b/src/engine/rebirthEngine.ts
@@ -5,28 +5,21 @@ import { SPECIES_ORDER } from "../data/species";
 export const REBIRTH_MIN_STAGE = 4;
 
 /** Divisor used in the Wisdom Token formula: floor(sqrt(totalTdEarned / divisor)). */
-export const WISDOM_TOKENS_DIVISOR = 1_000_000;
-
-/** Passive TD/s bonus per Wisdom Token: 5% per token. */
-export const WISDOM_MULTIPLIER_PER_TOKEN = 0.05;
+export const WISDOM_TOKENS_DIVISOR = 100_000;
 
 /**
  * Number of Wisdom Tokens earned for a Rebirth given the total TD earned
  * at the moment of rebirth.
  *
- * Formula: floor(sqrt(totalTdEarned / WISDOM_TOKENS_DIVISOR))
+ * Formula: floor(sqrt(totalTdEarned / WISDOM_TOKENS_DIVISOR) * tokenMagnetMultiplier)
+ * The optional `tokenMagnetMultiplier` scales the result (default 1).
  */
-export function computeWisdomTokens(totalTdEarned: number): number {
-  return Math.floor(Math.sqrt(totalTdEarned / WISDOM_TOKENS_DIVISOR));
-}
-
-/**
- * Permanent passive TD/s multiplier conferred by accumulated Wisdom Tokens.
- *
- * Formula: 1 + wisdomTokens * WISDOM_MULTIPLIER_PER_TOKEN
- */
-export function computeWisdomMultiplier(wisdomTokens: number): number {
-  return 1 + wisdomTokens * WISDOM_MULTIPLIER_PER_TOKEN;
+export function computeWisdomTokens(
+  totalTdEarned: number,
+  tokenMagnetMultiplier = 1,
+): number {
+  const base = Math.floor(Math.sqrt(totalTdEarned / WISDOM_TOKENS_DIVISOR));
+  return Math.floor(base * tokenMagnetMultiplier);
 }
 
 /** Returns true when the player is eligible to Rebirth. */

--- a/src/engine/tickEngine.ts
+++ b/src/engine/tickEngine.ts
@@ -2,15 +2,15 @@ import { BOOSTERS } from "../data/boosters";
 import { UPGRADES } from "../data/upgrades";
 import type { Mood } from "./moodEngine";
 import { getDecayedMood } from "./moodEngine";
-import { computeWisdomMultiplier } from "./rebirthEngine";
 import { computeBoosterMultiplier, getTotalTdPerSecond } from "./upgradeEngine";
 
 interface TickState {
   upgradeOwned: Record<string, number>;
   mood: Mood;
   moodChangedAt: number;
-  wisdomTokens?: number;
   boostersPurchased?: string[];
+  idleBoostMultiplier?: number;
+  speciesAutoGenMultiplier?: number;
 }
 
 interface TickResult {
@@ -23,7 +23,8 @@ export function computeTick(
   deltaSeconds: number,
   now: number,
 ): TickResult {
-  const wisdomMultiplier = computeWisdomMultiplier(state.wisdomTokens ?? 0);
+  const globalMultiplier =
+    (state.idleBoostMultiplier ?? 1) * (state.speciesAutoGenMultiplier ?? 1);
   const boosterMultiplier = computeBoosterMultiplier(
     BOOSTERS,
     state.boostersPurchased ?? [],
@@ -31,7 +32,7 @@ export function computeTick(
   const tdPerSecond = getTotalTdPerSecond(
     UPGRADES,
     state.upgradeOwned,
-    wisdomMultiplier,
+    globalMultiplier,
     boosterMultiplier,
   );
 

--- a/src/engine/upgradeEngine.test.ts
+++ b/src/engine/upgradeEngine.test.ts
@@ -58,6 +58,16 @@ describe("getUpgradeCost", () => {
     expect(getUpgradeCost(mockUpgrade2, 0)).toBe(500);
     expect(getUpgradeCost(mockUpgrade2, 3)).toBe(Math.floor(500 * 1.15 ** 3));
   });
+
+  it("applies custom costMultiplier", () => {
+    expect(getUpgradeCost(mockUpgrade, 1, 1.1)).toBe(Math.floor(100 * 1.1));
+  });
+
+  it("defaults to COST_MULTIPLIER when costMultiplier is omitted", () => {
+    expect(getUpgradeCost(mockUpgrade, 3)).toBe(
+      getUpgradeCost(mockUpgrade, 3, COST_MULTIPLIER),
+    );
+  });
 });
 
 describe("getBulkCost", () => {
@@ -176,7 +186,7 @@ describe("getTotalTdPerSecond", () => {
     expect(getTotalTdPerSecond([], { "test-upgrade": 5 })).toBe(0);
   });
 
-  it("applies wisdomMultiplier correctly", () => {
+  it("applies globalMultiplier correctly", () => {
     const owned = { "test-upgrade": 1 };
     expect(getTotalTdPerSecond([mockUpgrade], owned, 2)).toBeCloseTo(3);
   });

--- a/src/engine/upgradeEngine.ts
+++ b/src/engine/upgradeEngine.ts
@@ -5,8 +5,12 @@ import { getSynergyMultiplier } from "./synergyEngine";
 
 export const COST_MULTIPLIER = 1.15;
 
-export function getUpgradeCost(upgrade: Upgrade, owned: number): number {
-  return Math.floor(upgrade.baseCost * COST_MULTIPLIER ** owned);
+export function getUpgradeCost(
+  upgrade: Upgrade,
+  owned: number,
+  costMultiplier = COST_MULTIPLIER,
+): number {
+  return Math.floor(upgrade.baseCost * costMultiplier ** owned);
 }
 
 /**
@@ -17,12 +21,13 @@ export function getBulkCost(
   upgrade: Upgrade,
   owned: number,
   count: number,
+  costMultiplier = COST_MULTIPLIER,
 ): number {
   if (count <= 0) return 0;
-  if (count === 1) return getUpgradeCost(upgrade, owned);
-  const firstCost = upgrade.baseCost * COST_MULTIPLIER ** owned;
+  if (count === 1) return getUpgradeCost(upgrade, owned, costMultiplier);
+  const firstCost = upgrade.baseCost * costMultiplier ** owned;
   return Math.floor(
-    (firstCost * (COST_MULTIPLIER ** count - 1)) / (COST_MULTIPLIER - 1),
+    (firstCost * (costMultiplier ** count - 1)) / (costMultiplier - 1),
   );
 }
 
@@ -34,13 +39,14 @@ export function getMaxAffordable(
   upgrade: Upgrade,
   owned: number,
   budget: number,
+  costMultiplier = COST_MULTIPLIER,
 ): number {
   if (budget <= 0) return 0;
-  const firstCost = upgrade.baseCost * COST_MULTIPLIER ** owned;
+  const firstCost = upgrade.baseCost * costMultiplier ** owned;
   if (budget < firstCost) return 0;
   const n = Math.floor(
-    Math.log((budget * (COST_MULTIPLIER - 1)) / firstCost + 1) /
-      Math.log(COST_MULTIPLIER),
+    Math.log((budget * (costMultiplier - 1)) / firstCost + 1) /
+      Math.log(costMultiplier),
   );
   return Math.max(0, n);
 }
@@ -60,13 +66,13 @@ export function computeBoosterMultiplier(
 
 /**
  * Returns the total TD/s from owned upgrades, applying per-generator milestone
- * and synergy multipliers, then the global wisdom and booster multipliers.
- * Defaults to no bonus (×1) for wisdom and booster multipliers.
+ * and synergy multipliers, then the global multipliers (idle boost, species
+ * auto-gen bonus, booster multiplier).
  */
 export function getTotalTdPerSecond(
   upgrades: readonly Upgrade[],
   owned: Record<string, number>,
-  wisdomMultiplier = 1,
+  globalMultiplier = 1,
   boosterMultiplier = 1,
 ): number {
   let total = 0;
@@ -77,5 +83,5 @@ export function getTotalTdPerSecond(
     total +=
       upgrade.baseTdPerSecond * count * milestoneMultiplier * synergyMultiplier;
   }
-  return total * wisdomMultiplier * boosterMultiplier;
+  return total * globalMultiplier * boosterMultiplier;
 }

--- a/src/hooks/useGameLoop.ts
+++ b/src/hooks/useGameLoop.ts
@@ -1,6 +1,12 @@
 import { notifications } from "@mantine/notifications";
 import { useEffect, useRef } from "react";
 import { ACHIEVEMENTS } from "../data/achievements";
+import {
+  getGeneratorCostMultiplier,
+  getIdleBoostMultiplier,
+} from "../data/prestigeShop";
+import { getSpeciesBonus } from "../data/species";
+import { UPGRADES } from "../data/upgrades";
 import { checkAchievements } from "../engine/achievementEngine";
 import {
   checkEasterEggs,
@@ -8,6 +14,7 @@ import {
 } from "../engine/easterEggEngine";
 import { checkMilestones } from "../engine/milestoneEngine";
 import { computeTick } from "../engine/tickEngine";
+import { getUpgradeCost } from "../engine/upgradeEngine";
 import { useGameStore } from "../store";
 import { useUIStore } from "../store/uiStore";
 
@@ -54,7 +61,22 @@ export function useGameLoop() {
 
       const state = useGameStore.getState();
       const prevTdEarned = state.totalTdEarned;
-      const result = computeTick(state, deltaSeconds, now);
+
+      // Compute prestige multipliers for the tick engine
+      const idleBoost = getIdleBoostMultiplier(
+        state.prestigeUpgrades["idle-boost"] ?? 0,
+      );
+      const speciesAutoGen = getSpeciesBonus(state.currentSpecies).autoGen;
+
+      const result = computeTick(
+        {
+          ...state,
+          idleBoostMultiplier: idleBoost,
+          speciesAutoGenMultiplier: speciesAutoGen,
+        },
+        deltaSeconds,
+        now,
+      );
 
       if (result.trainingDataDelta > 0) {
         state.addTrainingData(result.trainingDataDelta);
@@ -85,6 +107,30 @@ export function useGameLoop() {
 
       // Increment total time played each tick
       state.incrementTimePlayed(deltaSeconds);
+
+      // Auto-Buy: purchase cheapest affordable generator once per tick
+      const autoBuyLevel = state.prestigeUpgrades["auto-buy"] ?? 0;
+      if (autoBuyLevel > 0) {
+        const current = useGameStore.getState();
+        const costMult = getGeneratorCostMultiplier(
+          current.prestigeUpgrades["generator-discount"] ?? 0,
+        );
+        let cheapest: { id: string; cost: number } | null = null;
+        for (const u of UPGRADES) {
+          if (current.evolutionStage < u.unlockStage) continue;
+          const owned = current.upgradeOwned[u.id] ?? 0;
+          const cost = getUpgradeCost(u, owned, costMult);
+          if (
+            cost <= current.trainingData &&
+            (cheapest === null || cost < cheapest.cost)
+          ) {
+            cheapest = { id: u.id, cost };
+          }
+        }
+        if (cheapest) {
+          current.purchaseUpgrade(cheapest.id);
+        }
+      }
 
       // Check for newly unlocked achievements after state updates
       const updatedState = useGameStore.getState();

--- a/src/hooks/useInterpolatedTd.ts
+++ b/src/hooks/useInterpolatedTd.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
+import { getIdleBoostMultiplier } from "../data/prestigeShop";
+import { getSpeciesBonus } from "../data/species";
 import { UPGRADES } from "../data/upgrades";
-import { computeWisdomMultiplier } from "../engine/rebirthEngine";
 import { getTotalTdPerSecond } from "../engine/upgradeEngine";
 import { useGameStore } from "../store";
 
@@ -57,11 +58,14 @@ export function useInterpolatedTd(): number {
       lastTimeRef.current = now;
 
       const state = useGameStore.getState();
-      const wisdomMultiplier = computeWisdomMultiplier(state.wisdomTokens);
+      const idleBoost = getIdleBoostMultiplier(
+        state.prestigeUpgrades["idle-boost"] ?? 0,
+      );
+      const speciesAutoGen = getSpeciesBonus(state.currentSpecies).autoGen;
       const tdPerSecond = getTotalTdPerSecond(
         UPGRADES,
         state.upgradeOwned,
-        wisdomMultiplier,
+        idleBoost * speciesAutoGen,
       );
 
       setDisplayTd((prev) =>

--- a/src/store/gameStore.test.ts
+++ b/src/store/gameStore.test.ts
@@ -295,6 +295,72 @@ describe("gameStore", () => {
     });
   });
 
+  describe("prestige", () => {
+    it("initial state has empty prestige fields", () => {
+      const state = useGameStore.getState();
+      expect(state.prestigeUpgrades).toEqual({});
+      expect(state.prestigeTokenBalance).toBe(0);
+    });
+
+    it("purchasePrestigeUpgrade deducts tokens and increments level", () => {
+      useGameStore.setState({ prestigeTokenBalance: 10 });
+      useGameStore.getState().purchasePrestigeUpgrade("click-mastery");
+      const state = useGameStore.getState();
+      expect(state.prestigeUpgrades["click-mastery"]).toBe(1);
+      expect(state.prestigeTokenBalance).toBe(7); // 10 - 3 cost
+    });
+
+    it("purchasePrestigeUpgrade no-ops at max level", () => {
+      // click-mastery has maxLevel 10, costPerLevel 3
+      useGameStore.setState({
+        prestigeTokenBalance: 100,
+        prestigeUpgrades: { "click-mastery": 10 },
+      });
+      useGameStore.getState().purchasePrestigeUpgrade("click-mastery");
+      const state = useGameStore.getState();
+      expect(state.prestigeUpgrades["click-mastery"]).toBe(10);
+      expect(state.prestigeTokenBalance).toBe(100);
+    });
+
+    it("purchasePrestigeUpgrade no-ops when cannot afford", () => {
+      useGameStore.setState({ prestigeTokenBalance: 0 });
+      useGameStore.getState().purchasePrestigeUpgrade("click-mastery");
+      const state = useGameStore.getState();
+      expect(state.prestigeUpgrades["click-mastery"]).toBeUndefined();
+    });
+
+    it("purchasePrestigeUpgrade no-ops for unknown id", () => {
+      useGameStore.setState({ prestigeTokenBalance: 100 });
+      useGameStore.getState().purchasePrestigeUpgrade("nonexistent");
+      expect(useGameStore.getState().prestigeTokenBalance).toBe(100);
+    });
+
+    it("performRebirth awards tokens and increments balance", () => {
+      useGameStore.setState({
+        totalTdEarned: 400_000, // floor(sqrt(400K/100K)) = 2 tokens
+        evolutionStage: 5,
+        prestigeTokenBalance: 0,
+        wisdomTokens: 0,
+      });
+      useGameStore.getState().performRebirth();
+      const state = useGameStore.getState();
+      expect(state.wisdomTokens).toBe(2);
+      expect(state.prestigeTokenBalance).toBe(2);
+    });
+
+    it("performRebirth preserves prestige upgrades", () => {
+      useGameStore.setState({
+        totalTdEarned: 400_000,
+        evolutionStage: 5,
+        prestigeUpgrades: { "click-mastery": 3 },
+      });
+      useGameStore.getState().performRebirth();
+      expect(useGameStore.getState().prestigeUpgrades).toEqual({
+        "click-mastery": 3,
+      });
+    });
+  });
+
   describe("crossedMilestones", () => {
     it("appends milestones via crossMilestones", () => {
       useGameStore.getState().crossMilestones([1_000, 10_000]);

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -2,7 +2,17 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { BOOSTERS } from "../data/boosters";
 import { CLICK_UPGRADES } from "../data/clickUpgrades";
+import {
+  getClickMasteryBonus,
+  getEvolutionThresholdMultiplier,
+  getGeneratorCostMultiplier,
+  getQuickStartTd,
+  getRetainedTiers,
+  getTokenMagnetMultiplier,
+  PRESTIGE_UPGRADES,
+} from "../data/prestigeShop";
 import type { Species } from "../data/species";
+import { getSpeciesBonus, SPECIES_ORDER } from "../data/species";
 import { UPGRADES } from "../data/upgrades";
 import { computeClickPower, getNextComboCount } from "../engine/clickEngine";
 import { getEvolutionStage } from "../engine/evolutionEngine";
@@ -34,6 +44,9 @@ export interface GameState {
   rebirthCount: number;
   currentSpecies: Species;
   unlockedSpecies: Species[];
+  // Prestige shop state — persists across rebirths
+  prestigeUpgrades: Record<string, number>;
+  prestigeTokenBalance: number;
   // Achievements — persists across rebirths
   unlockedAchievements: string[];
   // Booster upgrades — resets on rebirth
@@ -53,11 +66,12 @@ interface GameActions {
   purchaseBulkUpgrade: (id: string, count: number) => void;
   purchaseBooster: (id: string) => void;
   purchaseClickUpgrade: (id: string) => void;
+  purchasePrestigeUpgrade: (id: string) => void;
   markFirstEvolutionSeen: () => void;
   markFirstUpgradeSeen: () => void;
   setMood: (mood: Mood) => void;
   updateLastSaved: () => void;
-  performRebirth: () => void;
+  performRebirth: (selectedSpecies?: Species) => void;
   unlockAchievements: (ids: string[]) => void;
   unlockEasterEgg: (id: string) => void;
   incrementTimePlayed: (seconds: number) => void;
@@ -84,12 +98,19 @@ export const initialGameState: GameState = {
   rebirthCount: 0,
   currentSpecies: "GLORP",
   unlockedSpecies: ["GLORP"],
+  prestigeUpgrades: {},
+  prestigeTokenBalance: 0,
   boostersPurchased: [],
   unlockedAchievements: [],
   easterEggsUnlocked: [],
   totalTimePlayed: 0,
   crossedMilestones: [],
 };
+
+/** Helper: get a prestige upgrade level from state. */
+function pLevel(prestigeUpgrades: Record<string, number>, id: string): number {
+  return prestigeUpgrades[id] ?? 0;
+}
 
 export const useGameStore = create<GameStore>()(
   persist(
@@ -103,6 +124,10 @@ export const useGameStore = create<GameStore>()(
             state.lastClickTime,
             now,
           );
+          const clickMastery = getClickMasteryBonus(
+            pLevel(state.prestigeUpgrades, "click-mastery"),
+          );
+          const speciesBonus = getSpeciesBonus(state.currentSpecies);
           const clickPower = computeClickPower(
             {
               evolutionStage: state.evolutionStage,
@@ -112,13 +137,18 @@ export const useGameStore = create<GameStore>()(
             },
             CLICK_UPGRADES,
             now,
+            clickMastery,
+            speciesBonus.clickPower,
           );
           const newTotalTdEarned = state.totalTdEarned + clickPower;
+          const evoMultiplier = getEvolutionThresholdMultiplier(
+            pLevel(state.prestigeUpgrades, "evolution-accelerator"),
+          );
           return {
             trainingData: state.trainingData + clickPower,
             totalClicks: state.totalClicks + 1,
             totalTdEarned: newTotalTdEarned,
-            evolutionStage: getEvolutionStage(newTotalTdEarned),
+            evolutionStage: getEvolutionStage(newTotalTdEarned, evoMultiplier),
             lastSaved: now,
             comboCount: newComboCount,
             lastClickTime: now,
@@ -127,10 +157,13 @@ export const useGameStore = create<GameStore>()(
       addTrainingData: (amount) =>
         set((state) => {
           const newTotalTdEarned = state.totalTdEarned + amount;
+          const evoMultiplier = getEvolutionThresholdMultiplier(
+            pLevel(state.prestigeUpgrades, "evolution-accelerator"),
+          );
           return {
             trainingData: state.trainingData + amount,
             totalTdEarned: newTotalTdEarned,
-            evolutionStage: getEvolutionStage(newTotalTdEarned),
+            evolutionStage: getEvolutionStage(newTotalTdEarned, evoMultiplier),
             lastSaved: Date.now(),
           };
         }),
@@ -140,7 +173,10 @@ export const useGameStore = create<GameStore>()(
           if (!upgrade) return state;
 
           const owned = state.upgradeOwned[id] ?? 0;
-          const cost = getUpgradeCost(upgrade, owned);
+          const costMultiplier = getGeneratorCostMultiplier(
+            pLevel(state.prestigeUpgrades, "generator-discount"),
+          );
+          const cost = getUpgradeCost(upgrade, owned, costMultiplier);
 
           if (state.trainingData < cost) return state;
 
@@ -159,7 +195,10 @@ export const useGameStore = create<GameStore>()(
           if (!upgrade) return state;
 
           const owned = state.upgradeOwned[id] ?? 0;
-          const cost = getBulkCost(upgrade, owned, count);
+          const costMultiplier = getGeneratorCostMultiplier(
+            pLevel(state.prestigeUpgrades, "generator-discount"),
+          );
+          const cost = getBulkCost(upgrade, owned, count, costMultiplier);
 
           if (state.trainingData < cost) return state;
 
@@ -176,13 +215,8 @@ export const useGameStore = create<GameStore>()(
           const booster = BOOSTERS.find((b) => b.id === id);
           if (!booster) return state;
 
-          // Already purchased (one-time only)
           if (state.boostersPurchased.includes(id)) return state;
-
-          // Stage requirement not met
           if (state.evolutionStage < booster.unlockStage) return state;
-
-          // Not enough TD
           if (state.trainingData < booster.cost) return state;
 
           return {
@@ -198,13 +232,8 @@ export const useGameStore = create<GameStore>()(
           const upgrade = CLICK_UPGRADES.find((u) => u.id === id);
           if (!upgrade) return state;
 
-          // Already purchased (one-time only)
           if (state.clickUpgradesPurchased.includes(id)) return state;
-
-          // Not enough TD
           if (state.trainingData < upgrade.cost) return state;
-
-          // Stage requirement not met
           if (state.evolutionStage < upgrade.unlockStage) return state;
 
           return {
@@ -213,6 +242,25 @@ export const useGameStore = create<GameStore>()(
             lastSaved: Date.now(),
             mood: "Excited" as Mood,
             moodChangedAt: Date.now(),
+          };
+        }),
+      purchasePrestigeUpgrade: (id) =>
+        set((state) => {
+          const upgrade = PRESTIGE_UPGRADES.find((u) => u.id === id);
+          if (!upgrade) return state;
+
+          const currentLevel = pLevel(state.prestigeUpgrades, id);
+          if (currentLevel >= upgrade.maxLevel) return state;
+
+          const cost = upgrade.costPerLevel;
+          if (state.prestigeTokenBalance < cost) return state;
+
+          return {
+            prestigeUpgrades: {
+              ...state.prestigeUpgrades,
+              [id]: currentLevel + 1,
+            },
+            prestigeTokenBalance: state.prestigeTokenBalance - cost,
           };
         }),
       markFirstEvolutionSeen: () => set({ hasSeenFirstEvolution: true }),
@@ -237,24 +285,74 @@ export const useGameStore = create<GameStore>()(
         set((state) => ({
           crossedMilestones: [...state.crossedMilestones, ...thresholds],
         })),
-      performRebirth: () =>
+      performRebirth: (selectedSpecies) =>
         set((state) => {
           if (!canRebirth(state.evolutionStage)) return state;
 
-          const earned = computeWisdomTokens(state.totalTdEarned);
+          // Token Magnet bonus
+          const tokenMagnet = getTokenMagnetMultiplier(
+            pLevel(state.prestigeUpgrades, "token-magnet"),
+          );
+          // Species wisdom bonus
+          const speciesBonus = getSpeciesBonus(state.currentSpecies);
+          const earned = computeWisdomTokens(
+            state.totalTdEarned,
+            tokenMagnet * speciesBonus.wisdomBonus,
+          );
           const newWisdomTokens = state.wisdomTokens + earned;
-          const nextSpecies = getNextSpecies(state.currentSpecies);
-          const newUnlocked = state.unlockedSpecies.includes(nextSpecies)
-            ? state.unlockedSpecies
-            : [...state.unlockedSpecies, nextSpecies];
+          const newBalance = state.prestigeTokenBalance + earned;
+
+          // Unlock All Species check
+          const hasUnlockAll =
+            pLevel(state.prestigeUpgrades, "unlock-all-species") >= 1;
+
+          // Determine next species
+          let nextSpecies: Species;
+          if (selectedSpecies && hasUnlockAll) {
+            nextSpecies = selectedSpecies;
+          } else {
+            nextSpecies = getNextSpecies(state.currentSpecies);
+          }
+
+          // Unlocked species list
+          let newUnlocked: Species[];
+          if (hasUnlockAll) {
+            newUnlocked = [...SPECIES_ORDER];
+          } else {
+            newUnlocked = state.unlockedSpecies.includes(nextSpecies)
+              ? [...state.unlockedSpecies]
+              : [...state.unlockedSpecies, nextSpecies];
+          }
+
+          // Species Memory: retain owned generators in retained tiers
+          const retainedTiers = getRetainedTiers(
+            pLevel(state.prestigeUpgrades, "species-memory"),
+          );
+          const retainedUpgrades: Record<string, number> = {};
+          if (retainedTiers.length > 0) {
+            for (const u of UPGRADES) {
+              if (retainedTiers.includes(u.tier)) {
+                const count = state.upgradeOwned[u.id];
+                if (count && count > 0) {
+                  retainedUpgrades[u.id] = count;
+                }
+              }
+            }
+          }
+
+          // Quick Start TD
+          const quickStartTd = getQuickStartTd(
+            pLevel(state.prestigeUpgrades, "quick-start"),
+          );
 
           return {
             // Reset progression
-            trainingData: 0,
+            trainingData: quickStartTd,
             totalClicks: 0,
-            totalTdEarned: 0,
-            evolutionStage: 0,
-            upgradeOwned: {},
+            totalTdEarned: quickStartTd,
+            evolutionStage:
+              quickStartTd > 0 ? getEvolutionStage(quickStartTd) : 0,
+            upgradeOwned: retainedUpgrades,
             mood: "Neutral" as Mood,
             moodChangedAt: Date.now(),
             hasSeenFirstEvolution: false,
@@ -268,15 +366,28 @@ export const useGameStore = create<GameStore>()(
             crossedMilestones: [],
             // Persist rebirth rewards
             wisdomTokens: newWisdomTokens,
+            prestigeTokenBalance: newBalance,
             rebirthCount: state.rebirthCount + 1,
             currentSpecies: nextSpecies,
             unlockedSpecies: newUnlocked,
-            // easterEggsUnlocked and totalTimePlayed persist across rebirths
           };
         }),
     }),
     {
       name: "glorp-game-state",
+      merge: (persisted, current) => {
+        const saved = persisted as Partial<GameState> | undefined;
+        if (!saved) return current;
+        // Migrate old saves: convert wisdomTokens to spendable balance
+        const merged = { ...current, ...saved };
+        if (saved.prestigeUpgrades === undefined) {
+          merged.prestigeUpgrades = {};
+        }
+        if (saved.prestigeTokenBalance === undefined) {
+          merged.prestigeTokenBalance = saved.wisdomTokens ?? 0;
+        }
+        return merged;
+      },
     },
   ),
 );

--- a/src/utils/saveManager.test.ts
+++ b/src/utils/saveManager.test.ts
@@ -5,6 +5,7 @@ import { initialGameState, useGameStore } from "../store/gameStore";
 import {
   applySave,
   exportSave,
+  migrateSave,
   parseSaveFile,
   resetGame,
   validateSave,
@@ -33,6 +34,8 @@ const validSave: GameState = {
   comboCount: 0,
   lastClickTime: 0,
   crossedMilestones: [],
+  prestigeUpgrades: {},
+  prestigeTokenBalance: 0,
 };
 
 beforeEach(() => {
@@ -149,6 +152,42 @@ describe("exportSave", () => {
     exportSave();
 
     expect(capturedDownload).toMatch(/glorp-save-\d+\.json/);
+  });
+});
+
+describe("migrateSave", () => {
+  it("converts wisdomTokens to prestigeTokenBalance for old saves", () => {
+    const oldSave = { ...validSave, wisdomTokens: 10 } as GameState;
+    // Remove prestige fields to simulate an old save
+    const record = oldSave as unknown as Record<string, unknown>;
+    delete record.prestigeTokenBalance;
+    delete record.prestigeUpgrades;
+
+    const migrated = migrateSave(oldSave);
+    expect(migrated.prestigeTokenBalance).toBe(10);
+    expect(migrated.prestigeUpgrades).toEqual({});
+  });
+
+  it("preserves existing prestige fields for new saves", () => {
+    const newSave: GameState = {
+      ...validSave,
+      prestigeUpgrades: { "quick-start": 2 },
+      prestigeTokenBalance: 5,
+    };
+    const migrated = migrateSave(newSave);
+    expect(migrated.prestigeTokenBalance).toBe(5);
+    expect(migrated.prestigeUpgrades).toEqual({ "quick-start": 2 });
+  });
+
+  it("defaults prestigeTokenBalance to 0 when wisdomTokens is also 0", () => {
+    const oldSave = { ...validSave, wisdomTokens: 0 } as GameState;
+    const record = oldSave as unknown as Record<string, unknown>;
+    delete record.prestigeTokenBalance;
+    delete record.prestigeUpgrades;
+
+    const migrated = migrateSave(oldSave);
+    expect(migrated.prestigeTokenBalance).toBe(0);
+    expect(migrated.prestigeUpgrades).toEqual({});
   });
 });
 

--- a/src/utils/saveManager.ts
+++ b/src/utils/saveManager.ts
@@ -27,10 +27,41 @@ export function validateSave(data: unknown): data is GameState {
   return REQUIRED_KEYS.every((key) => key in (data as object));
 }
 
+/**
+ * Migrate old saves that lack prestige fields.
+ * Old saves have `wisdomTokens` but no `prestigeTokenBalance`.
+ * Convert: all accumulated tokens become the spendable balance.
+ */
+export function migrateSave(data: GameState): GameState {
+  const record = data as unknown as Record<string, unknown>;
+  if (!("prestigeTokenBalance" in record)) {
+    return {
+      ...data,
+      prestigeUpgrades: {},
+      prestigeTokenBalance: data.wisdomTokens ?? 0,
+    };
+  }
+  // Ensure defaults for any missing prestige fields
+  return {
+    ...data,
+    prestigeUpgrades: data.prestigeUpgrades ?? {},
+    prestigeTokenBalance: data.prestigeTokenBalance ?? 0,
+  };
+}
+
 export function exportSave(): void {
   const state = useGameStore.getState();
+  const exportKeys: (keyof GameState)[] = [
+    ...REQUIRED_KEYS,
+    "prestigeUpgrades",
+    "prestigeTokenBalance",
+    "boostersPurchased",
+    "easterEggsUnlocked",
+    "totalTimePlayed",
+    "crossedMilestones",
+  ];
   const saveData: Partial<GameState> = {};
-  for (const key of REQUIRED_KEYS) {
+  for (const key of exportKeys) {
     (saveData as Record<string, unknown>)[key] = state[key];
   }
   const json = JSON.stringify(saveData, null, 2);
@@ -54,7 +85,7 @@ export function parseSaveFile(file: File): Promise<GameState> {
           reject(new Error("Invalid save file: missing required fields"));
           return;
         }
-        resolve(data);
+        resolve(migrateSave(data));
       } catch {
         reject(new Error("Failed to parse save file"));
       }
@@ -65,7 +96,7 @@ export function parseSaveFile(file: File): Promise<GameState> {
 }
 
 export function applySave(save: GameState): void {
-  useGameStore.setState(save);
+  useGameStore.setState(migrateSave(save));
 }
 
 export function resetGame(): void {


### PR DESCRIPTION
## Summary

Implements the Prestige Shop system with spendable Wisdom Tokens, species passive bonuses, and 10 purchasable prestige upgrades. Removes the old passive 5%-per-token TD/s bonus in favor of an active upgrade system.

## Changes

### Core System
- **Token formula rebalance**: Changed divisor from 1M to 100K (`floor(sqrt(totalTdEarned / 100_000))`) for faster token earning
- **Removed passive multiplier**: `computeWisdomMultiplier` and `WISDOM_MULTIPLIER_PER_TOKEN` removed entirely
- **Spendable token balance**: New `prestigeTokenBalance` field tracks spendable tokens separately from lifetime `wisdomTokens`

### Prestige Shop (10 upgrades)
| Upgrade | Cost/Level | Max | Effect |
|---------|-----------|-----|--------|
| Quick Start | 5 | 3 | Start runs with 1K/10K/100K TD |
| Auto-Buy | 10 | 1 | Auto-purchases cheapest generator each tick |
| Click Mastery | 3 | 10 | +1 base click power per level |
| Generator Discount | 8 | 3 | Reduces cost multiplier by 0.01 per level |
| Idle Boost | 5 | 5 | +25% auto-gen TD/s per level |
| Offline Efficiency | 5 | 3 | +10% offline rate per level (base 50%) |
| Evolution Accelerator | 15 | 3 | −10% evolution thresholds per level |
| Species Memory | 20 | 5 | Retain one generator tier across rebirth per level |
| Token Magnet | 10 | 5 | +20% tokens earned on rebirth per level |
| Unlock All Species | 50 | 1 | Choose any species on rebirth |

### Species Passive Bonuses
- **GLORP**: No bonus (1.0× all)
- **ZAPPY**: +25% auto-gen
- **CHONK**: +50% click power
- **WISP**: +25% wisdom token earnings
- **MEGA-GLORP**: +10% everything

### Engine Changes
- `upgradeEngine`: Optional `costMultiplier` param on cost functions (Generator Discount)
- `clickEngine`: Optional `clickMasteryBonus` and `speciesClickMultiplier` params
- `offlineEngine`: Optional `offlineEfficiency` param (Offline Efficiency upgrade)
- `evolutionEngine`: Optional `thresholdMultiplier` param (Evolution Accelerator)
- `tickEngine`: Uses `idleBoostMultiplier` and `speciesAutoGenMultiplier` instead of wisdom multiplier

### UI
- New `PrestigeShop` modal (accessible after first rebirth from PetDisplay)
- Updated `RebirthModal` with species selection dropdown (when Unlock All Species purchased), token balance display, and Token Magnet preview
- Updated `StatsBar` to show token balance instead of wisdom multiplier

### Save Migration
- Zustand persist `merge` function auto-migrates on load
- `migrateSave()` handles file import/export
- Old saves: `wisdomTokens` value converts to `prestigeTokenBalance`

## Story
[Phase 8: 8.4 Prestige shop & wisdom token rebalance](https://github.com/AshDevFr/GLORP/issues/45)

Closes #45

## Testing
- 459 tests pass (27 test files)
- `tsc -b --noEmit` clean
- `biome check` clean
- New test files: `prestigeShop.test.ts` (29 tests), `species.test.ts` (8 tests)
- Updated test files: `rebirthEngine.test.ts`, `achievementEngine.test.ts`, `saveManager.test.ts`, `gameStore.test.ts`, `upgradeEngine.test.ts`, `achievements.test.ts`

— Sean (4shClaw senior developer agent)