### PR TITLE
feat: add 8 Phase 8 achievements (#48)

### DIFF
--- a/src/components/PrestigeShop.tsx
+++ b/src/components/PrestigeShop.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   Title,
 } from "@mantine/core";
+import { useEffect } from "react";
 import { PRESTIGE_UPGRADES } from "../data/prestigeShop";
 import { useGameStore } from "../store";
 
@@ -23,6 +24,13 @@ export function PrestigeShop({ opened, onClose }: PrestigeShopProps) {
   const purchasePrestigeUpgrade = useGameStore(
     (s) => s.purchasePrestigeUpgrade,
   );
+  const markPrestigeShopOpened = useGameStore((s) => s.markPrestigeShopOpened);
+
+  useEffect(() => {
+    if (opened) {
+      markPrestigeShopOpened();
+    }
+  }, [opened, markPrestigeShopOpened]);
 
   return (
     <Modal

--- a/src/data/achievements.test.ts
+++ b/src/data/achievements.test.ts
@@ -27,6 +27,7 @@ const emptyState: GameState = {
   crossedMilestones: [],
   prestigeUpgrades: {},
   prestigeTokenBalance: 0,
+  hasOpenedPrestigeShop: false,
 };
 
 describe("ACHIEVEMENTS", () => {

--- a/src/data/achievements.ts
+++ b/src/data/achievements.ts
@@ -1,4 +1,8 @@
 import type { GameState } from "../store/gameStore";
+import { BOOSTERS } from "./boosters";
+import { PRESTIGE_UPGRADES } from "./prestigeShop";
+import { SPECIES_ORDER } from "./species";
+import { SYNERGIES } from "./synergies";
 
 export type AchievementId = string;
 
@@ -107,5 +111,59 @@ export const ACHIEVEMENTS: readonly Achievement[] = [
     name: "Serial Rebirther",
     description: "Perform 5 Rebirths",
     condition: (s) => s.rebirthCount >= 5,
+  },
+  {
+    id: "click-storm",
+    name: "Click Storm",
+    description: "10x click combo! Your fingers are on fire!",
+    condition: (s) => s.comboCount >= 10,
+  },
+  {
+    id: "synergy-first",
+    name: "Synergy!",
+    description: "Unlocked your first cross-generator synergy",
+    condition: (s) =>
+      SYNERGIES.some(
+        (syn) => (s.upgradeOwned[syn.sourceId] ?? 0) >= syn.threshold,
+      ),
+  },
+  {
+    id: "bulk-buyer",
+    name: "Bulk Buyer",
+    description: "100 of a single generator. Now THAT's commitment.",
+    condition: (s) => Object.values(s.upgradeOwned).some((c) => c >= 100),
+  },
+  {
+    id: "window-shopper",
+    name: "Window Shopper",
+    description: "Browsing the prestige shop for the first time",
+    condition: (s) => s.hasOpenedPrestigeShop,
+  },
+  {
+    id: "fully-loaded",
+    name: "Fully Loaded",
+    description: "Every prestige upgrade maxed. You are GLORP's champion.",
+    condition: (s) =>
+      PRESTIGE_UPGRADES.every(
+        (u) => (s.prestigeUpgrades[u.id] ?? 0) >= u.maxLevel,
+      ),
+  },
+  {
+    id: "multiplied",
+    name: "Multiplied!",
+    description: "2x × 3x × 5x × 10x = 300x. Math is beautiful.",
+    condition: (s) => BOOSTERS.every((b) => s.boostersPurchased.includes(b.id)),
+  },
+  {
+    id: "species-collector",
+    name: "Species Collector",
+    description: "Played as every species. Which is your favorite?",
+    condition: (s) => s.unlockedSpecies.length >= SPECIES_ORDER.length,
+  },
+  {
+    id: "td-1t",
+    name: "Trillionaire",
+    description: "A trillion training data points. GLORP transcends.",
+    condition: (s) => s.totalTdEarned >= 1_000_000_000_000,
   },
 ];

--- a/src/engine/achievementEngine.test.ts
+++ b/src/engine/achievementEngine.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { Species } from "../data/species";
 import type { GameState } from "../store/gameStore";
 import { checkAchievements } from "./achievementEngine";
 
@@ -27,6 +28,7 @@ const baseState: GameState = {
   crossedMilestones: [],
   prestigeUpgrades: {},
   prestigeTokenBalance: 0,
+  hasOpenedPrestigeShop: false,
 };
 
 describe("checkAchievements", () => {
@@ -117,14 +119,126 @@ describe("checkAchievements", () => {
     expect(result).not.toContain("stage-4");
   });
 
+  it("returns click-storm when comboCount reaches 10", () => {
+    const state = { ...baseState, comboCount: 10 };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("click-storm");
+  });
+
+  it("returns synergy-first when a synergy threshold is met", () => {
+    const state = {
+      ...baseState,
+      upgradeOwned: { "neural-notepad": 50 },
+    };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("synergy-first");
+  });
+
+  it("returns bulk-buyer when a generator reaches 100 owned", () => {
+    const state = {
+      ...baseState,
+      upgradeOwned: { "neural-notepad": 100 },
+    };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("bulk-buyer");
+  });
+
+  it("returns window-shopper when prestige shop has been opened", () => {
+    const state = { ...baseState, hasOpenedPrestigeShop: true };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("window-shopper");
+  });
+
+  it("returns fully-loaded when all prestige upgrades are at max level", () => {
+    const state = {
+      ...baseState,
+      prestigeUpgrades: {
+        "quick-start": 3,
+        "auto-buy": 1,
+        "click-mastery": 10,
+        "generator-discount": 3,
+        "idle-boost": 5,
+        "offline-efficiency": 3,
+        "evolution-accelerator": 3,
+        "species-memory": 5,
+        "token-magnet": 5,
+        "unlock-all-species": 1,
+      },
+    };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("fully-loaded");
+  });
+
+  it("returns multiplied when all 4 boosters are purchased", () => {
+    const state = {
+      ...baseState,
+      boostersPurchased: [
+        "series-a-funding",
+        "hype-train",
+        "consciousness-clause",
+        "dyson-sphere",
+      ],
+    };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("multiplied");
+  });
+
+  it("returns species-collector when all 5 species are unlocked", () => {
+    const state = {
+      ...baseState,
+      unlockedSpecies: [
+        "GLORP",
+        "ZAPPY",
+        "CHONK",
+        "WISP",
+        "MEGA-GLORP",
+      ] as Species[],
+    };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("species-collector");
+  });
+
+  it("returns td-1t when totalTdEarned reaches 1 trillion", () => {
+    const state = { ...baseState, totalTdEarned: 1_000_000_000_000 };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("td-1t");
+  });
+
   it("excludes all achievements when all are already unlocked", () => {
     const state = {
       ...baseState,
       totalClicks: 100_000,
-      totalTdEarned: 2_000_000_000,
+      totalTdEarned: 1_000_000_000_000,
       evolutionStage: 4,
       rebirthCount: 10,
-      upgradeOwned: { a: 10 },
+      upgradeOwned: { "neural-notepad": 100 },
+      comboCount: 10,
+      hasOpenedPrestigeShop: true,
+      prestigeUpgrades: {
+        "quick-start": 3,
+        "auto-buy": 1,
+        "click-mastery": 10,
+        "generator-discount": 3,
+        "idle-boost": 5,
+        "offline-efficiency": 3,
+        "evolution-accelerator": 3,
+        "species-memory": 5,
+        "token-magnet": 5,
+        "unlock-all-species": 1,
+      },
+      boostersPurchased: [
+        "series-a-funding",
+        "hype-train",
+        "consciousness-clause",
+        "dyson-sphere",
+      ],
+      unlockedSpecies: [
+        "GLORP",
+        "ZAPPY",
+        "CHONK",
+        "WISP",
+        "MEGA-GLORP",
+      ] as Species[],
     };
     const allIds = [
       "first-click",
@@ -143,6 +257,14 @@ describe("checkAchievements", () => {
       "td-1b",
       "first-rebirth",
       "rebirths-5",
+      "click-storm",
+      "synergy-first",
+      "bulk-buyer",
+      "window-shopper",
+      "fully-loaded",
+      "multiplied",
+      "species-collector",
+      "td-1t",
     ];
     const result = checkAchievements(state, allIds);
     expect(result).toEqual([]);

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -47,6 +47,7 @@ export interface GameState {
   // Prestige shop state — persists across rebirths
   prestigeUpgrades: Record<string, number>;
   prestigeTokenBalance: number;
+  hasOpenedPrestigeShop: boolean;
   // Achievements — persists across rebirths
   unlockedAchievements: string[];
   // Booster upgrades — resets on rebirth
@@ -67,6 +68,7 @@ interface GameActions {
   purchaseBooster: (id: string) => void;
   purchaseClickUpgrade: (id: string) => void;
   purchasePrestigeUpgrade: (id: string) => void;
+  markPrestigeShopOpened: () => void;
   markFirstEvolutionSeen: () => void;
   markFirstUpgradeSeen: () => void;
   setMood: (mood: Mood) => void;
@@ -100,6 +102,7 @@ export const initialGameState: GameState = {
   unlockedSpecies: ["GLORP"],
   prestigeUpgrades: {},
   prestigeTokenBalance: 0,
+  hasOpenedPrestigeShop: false,
   boostersPurchased: [],
   unlockedAchievements: [],
   easterEggsUnlocked: [],
@@ -263,6 +266,7 @@ export const useGameStore = create<GameStore>()(
             prestigeTokenBalance: state.prestigeTokenBalance - cost,
           };
         }),
+      markPrestigeShopOpened: () => set({ hasOpenedPrestigeShop: true }),
       markFirstEvolutionSeen: () => set({ hasSeenFirstEvolution: true }),
       markFirstUpgradeSeen: () => set({ hasSeenFirstUpgrade: true }),
       setMood: (mood) => set({ mood, moodChangedAt: Date.now() }),
@@ -385,6 +389,9 @@ export const useGameStore = create<GameStore>()(
         }
         if (saved.prestigeTokenBalance === undefined) {
           merged.prestigeTokenBalance = saved.wisdomTokens ?? 0;
+        }
+        if (saved.hasOpenedPrestigeShop === undefined) {
+          merged.hasOpenedPrestigeShop = false;
         }
         return merged;
       },

--- a/src/utils/saveManager.test.ts
+++ b/src/utils/saveManager.test.ts
@@ -36,6 +36,7 @@ const validSave: GameState = {
   crossedMilestones: [],
   prestigeUpgrades: {},
   prestigeTokenBalance: 0,
+  hasOpenedPrestigeShop: false,
 };
 
 beforeEach(() => {

--- a/src/utils/saveManager.ts
+++ b/src/utils/saveManager.ts
@@ -39,6 +39,7 @@ export function migrateSave(data: GameState): GameState {
       ...data,
       prestigeUpgrades: {},
       prestigeTokenBalance: data.wisdomTokens ?? 0,
+      hasOpenedPrestigeShop: false,
     };
   }
   // Ensure defaults for any missing prestige fields
@@ -46,6 +47,7 @@ export function migrateSave(data: GameState): GameState {
     ...data,
     prestigeUpgrades: data.prestigeUpgrades ?? {},
     prestigeTokenBalance: data.prestigeTokenBalance ?? 0,
+    hasOpenedPrestigeShop: data.hasOpenedPrestigeShop ?? false,
   };
 }
 
@@ -55,6 +57,7 @@ export function exportSave(): void {
     ...REQUIRED_KEYS,
     "prestigeUpgrades",
     "prestigeTokenBalance",
+    "hasOpenedPrestigeShop",
     "boostersPurchased",
     "easterEggsUnlocked",
     "totalTimePlayed",


### PR DESCRIPTION
## Summary

Adds 8 new achievements that celebrate the Phase 8 mechanics (click combos, synergies, bulk buying, prestige shop, species unlocking, and TD milestones). Closes #48.

## Changes

- `src/data/achievements.ts` — 8 new achievement definitions; imports `SYNERGIES`, `PRESTIGE_UPGRADES`, `BOOSTERS`, `SPECIES_ORDER` for conditions
- `src/store/gameStore.ts` — adds `hasOpenedPrestigeShop: boolean` to `GameState`, `initialGameState`, `GameActions`, and the persist migration handler
- `src/components/PrestigeShop.tsx` — calls `markPrestigeShopOpened()` via `useEffect` whenever the modal is opened
- `src/utils/saveManager.ts` — adds `hasOpenedPrestigeShop` to `exportKeys` and migrates it to `false` in old saves
- `src/engine/achievementEngine.test.ts` — adds `hasOpenedPrestigeShop: false` to fixture + 8 new test cases + updated "excludes all" test
- `src/data/achievements.test.ts` — adds `hasOpenedPrestigeShop: false` to fixture
- `src/utils/saveManager.test.ts` — adds `hasOpenedPrestigeShop: false` to fixture

## New Achievements

| ID | Name | Condition |
|---|---|---|
| `click-storm` | Click Storm | `comboCount >= 10` |
| `synergy-first` | Synergy! | any synergy threshold met |
| `bulk-buyer` | Bulk Buyer | any generator owned ≥ 100 |
| `window-shopper` | Window Shopper | prestige shop opened once |
| `fully-loaded` | Fully Loaded | all 10 prestige upgrades at max level |
| `multiplied` | Multiplied! | all 4 boosters purchased |
| `species-collector` | Species Collector | all 5 species unlocked |
| `td-1t` | Trillionaire | `totalTdEarned >= 1,000,000,000,000` |

## Story

[[Phase 8] 8.7 New achievements for Phase 8 systems](https://github.com/AshDevFr/GLORP/issues/48)

## Testing

- 479 tests passing (28 test files)
- `tsc -b` clean
- `npx biome check --write .` clean (reordered imports in achievements.ts)
- All 8 new achievement conditions verified with dedicated test cases

— Devon (4shClaw developer agent)