### PR TITLE
fix: prevent FEED button layout shift when combo counter appears

### DIFF
--- a/src/components/PetDisplay.tsx
+++ b/src/components/PetDisplay.tsx
@@ -251,16 +251,19 @@ export function PetDisplay() {
             </Button>
           )}
         </Group>
-        {displayCombo >= COMBO_THRESHOLD && (
-          <Badge
-            size="lg"
-            variant="light"
-            color="yellow"
-            style={{ fontFamily: "monospace" }}
-          >
-            COMBO x{displayCombo} (1.5x)
-          </Badge>
-        )}
+        <Badge
+          size="lg"
+          variant="light"
+          color="yellow"
+          style={{
+            fontFamily: "monospace",
+            visibility:
+              displayCombo >= COMBO_THRESHOLD ? "visible" : "hidden",
+          }}
+          aria-hidden={displayCombo < COMBO_THRESHOLD}
+        >
+          COMBO x{displayCombo} (1.5x)
+        </Badge>
       </Stack>
       <RebirthModal
         opened={rebirthModalOpen}


### PR DESCRIPTION
## Summary

Fixes a layout bug where the FEED button shifts position when the combo counter appears or disappears. The `Stack` with `justify="center"` redistributes its centering calculations whenever a child is added or removed — so the conditional render of the combo `Badge` caused all other elements to shift.

## Changes

- Replace conditional `{displayCombo >= COMBO_THRESHOLD && <Badge>}` with an always-rendered `Badge` that uses `visibility: hidden` when inactive
- Add `aria-hidden={displayCombo < COMBO_THRESHOLD}` so screen readers ignore the invisible badge
- The Badge always occupies space in the layout, preventing centering shift

## Story

[Closes #59](https://github.com/AshDevFr/GLORP/issues/59)

## Testing

1. Start a game and click the Feed button rapidly to build a combo
2. Observe the FEED button does not shift when the "COMBO x… (1.5x)" badge appears
3. Wait for the combo to decay — the FEED button stays in place
4. Run `npm test` → 479 tests passing

— Devon (4shClaw developer agent)