### PR TITLE
feat: center creature vertically and multi-column generator grid

### DIFF
--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -120,7 +120,7 @@ export function GameLayout() {
       </AppShell.Header>
 
       <AppShell.Main>
-        <Grid gutter={0} style={{ minHeight: "calc(100vh - 44px)" }}>
+        <Grid gutter={0} className="game-main-grid">
           <Grid.Col span={{ base: 12, md: 8 }}>
             <PetDisplay />
           </Grid.Col>

--- a/src/components/UpgradesPanel.tsx
+++ b/src/components/UpgradesPanel.tsx
@@ -82,6 +82,13 @@ export function UpgradesPanel() {
     (tc) => evolutionStage >= tc.unlockStage,
   );
 
+  // Use a 2-column grid for generator cards when there are enough to warrant it
+  const totalVisibleUpgrades = visibleTiers.reduce(
+    (sum, tc) => sum + UPGRADES.filter((u) => u.tier === tc.tier).length,
+    0,
+  );
+  const useMultiColumn = totalVisibleUpgrades >= 6;
+
   // Show click upgrades that are unlocked at or below current stage
   const visibleClickUpgrades = CLICK_UPGRADES.filter(
     (u) => evolutionStage >= u.unlockStage,
@@ -148,18 +155,35 @@ export function UpgradesPanel() {
                 <Text size="xs" fw={700} ff="monospace" c="dimmed" mb="xs">
                   {tc.label}
                 </Text>
-                {tierUpgrades.map((upgrade) => (
-                  <UpgradeCard
-                    key={upgrade.id}
-                    upgrade={upgrade}
-                    owned={upgradeOwned[upgrade.id] ?? 0}
-                    allOwned={upgradeOwned}
-                    trainingData={trainingData}
-                    buyMode={buyMode}
-                    onPurchase={purchaseBulkUpgrade}
-                    costMultiplier={costMultiplier}
-                  />
-                ))}
+                <div
+                  style={
+                    useMultiColumn
+                      ? {
+                          display: "grid",
+                          gridTemplateColumns:
+                            "repeat(auto-fill, minmax(280px, 1fr))",
+                          gap: "var(--mantine-spacing-xs)",
+                        }
+                      : {
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: "var(--mantine-spacing-xs)",
+                        }
+                  }
+                >
+                  {tierUpgrades.map((upgrade) => (
+                    <UpgradeCard
+                      key={upgrade.id}
+                      upgrade={upgrade}
+                      owned={upgradeOwned[upgrade.id] ?? 0}
+                      allOwned={upgradeOwned}
+                      trainingData={trainingData}
+                      buyMode={buyMode}
+                      onPurchase={purchaseBulkUpgrade}
+                      costMultiplier={costMultiplier}
+                    />
+                  ))}
+                </div>
               </div>
             );
           })}

--- a/src/global.css
+++ b/src/global.css
@@ -177,6 +177,21 @@ body {
   }
 }
 
+/* ── Game layout: lock panels to viewport height on desktop ─────────── */
+
+.game-main-grid {
+  min-height: calc(100vh - 44px);
+}
+
+@media (min-width: 62em) {
+  /* On desktop the panels sit side-by-side; lock the grid to the viewport
+     so each panel scrolls internally rather than growing the page. */
+  .game-main-grid {
+    height: calc(100vh - 44px);
+    overflow: hidden;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .float-particle {
     animation: none;


### PR DESCRIPTION
## Summary

Fixes two related layout problems: the creature drifting to the top of its panel as the upgrades list grows, and the upgrades panel becoming excessively tall with many generators.

## Root cause

The `Grid` used `minHeight: calc(100vh - 44px)`, which let the grid row grow as tall as the tallest column (the upgrades panel). This had two effects:
1. The UpgradesPanel's internal `ScrollArea` never had a bounded parent height, so it expanded to show all content instead of scrolling.
2. The PetDisplay column grew equally tall, centering the creature far below the visible viewport.

## Changes

### `src/global.css`
- Added `.game-main-grid` class: `min-height` on mobile (panels stack, natural page scroll), `height: calc(100vh - 44px)` + `overflow: hidden` on desktop (≥ 62em) to lock panels to viewport height.

### `src/components/GameLayout.tsx`
- Replaced `style={{ minHeight: "calc(100vh - 44px)" }}` on the Grid with `className="game-main-grid"`.
- No other changes — the existing `Stack justify="center" align="center" h="100%"` inside PetDisplay and the existing `ScrollArea flex: 1` inside UpgradesPanel both work correctly once the grid height is properly bounded.

### `src/components/UpgradesPanel.tsx`
- Compute `totalVisibleUpgrades` (sum of generators across visible tiers).
- When `totalVisibleUpgrades >= 6` (true from stage 0: 3 Garage Lab + 3 Startup = 6), wrap each tier's generator cards in a CSS grid with `repeat(auto-fill, minmax(280px, 1fr))`. This cuts the vertical height of the generators section roughly in half on wide viewports.
- Click Boosters and Global Boosters sections remain single-column at top/bottom of the scroll area.
- The `minmax(280px, 1fr)` layout collapses to a single column automatically on narrow panels — no extra media queries needed.

## Acceptance criteria

- [x] Creature ASCII art vertically centered at all times regardless of upgrades panel height
- [x] Left panel uses `align-items: center` equivalent (`Stack justify="center"` with bounded height)
- [x] Upgrades panel uses 2-column grid when ≥ 6 visible generators
- [x] Click Boosters pinned at top, Global Boosters at bottom — not buried
- [x] Layout responsive: collapses to single column on narrow viewports (auto-fill minmax)
- [x] Prestige Shop button lives in PetDisplay, unaffected

## Testing

1. `npm test` → 479 tests passing, tsc clean, biome clean
2. Desktop (wide): creature stays centred as generator tiers unlock; generators display in 2 columns
3. Mobile / narrow panel: generator cards fall back to a single column automatically
4. Prestige Shop button remains visible in the left panel

Closes #60

— Devon (4shClaw developer agent)