### PR TITLE
feat: replace k/M/B abbreviations with full comma-formatted numbers

### DIFF
--- a/src/components/PrestigeShop.tsx
+++ b/src/components/PrestigeShop.tsx
@@ -12,6 +12,7 @@ import {
 import { useEffect } from "react";
 import { PRESTIGE_UPGRADES } from "../data/prestigeShop";
 import { useGameStore } from "../store";
+import { formatNumber } from "../utils/formatNumber";
 
 interface PrestigeShopProps {
   opened: boolean;
@@ -48,7 +49,7 @@ export function PrestigeShop({ opened, onClose }: PrestigeShopProps) {
         <Text ta="center" size="sm" ff="monospace" c="yellow.4" fw={600}>
           Wisdom Tokens:{" "}
           <Text span fw={700}>
-            {prestigeTokenBalance} ✦
+            {formatNumber(prestigeTokenBalance)} ✦
           </Text>
         </Text>
 

--- a/src/store/settingsStore.test.ts
+++ b/src/store/settingsStore.test.ts
@@ -10,7 +10,7 @@ describe("useSettingsStore", () => {
     const state = useSettingsStore.getState();
     expect(state.crtEnabled).toBe(false);
     expect(state.animationsDisabled).toBe(false);
-    expect(state.numberFormat).toBe("compact");
+    expect(state.numberFormat).toBe("full");
   });
 
   it("setCrtEnabled sets crtEnabled to true", () => {

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -25,7 +25,7 @@ export const initialSettings: SettingsState = {
   crtEnabled: false,
   animationsDisabled: false,
   buyMode: 1,
-  numberFormat: "compact",
+  numberFormat: "full",
 };
 
 export const useSettingsStore = create<SettingsStore>()(

--- a/src/utils/formatNumber.test.ts
+++ b/src/utils/formatNumber.test.ts
@@ -26,72 +26,55 @@ describe("formatNumber", () => {
     });
   });
 
-  describe("thousands (K)", () => {
+  describe("thousands", () => {
     it("formats exactly 1,000", () => {
-      expect(formatNumber(1_000)).toBe("1.00K");
+      expect(formatNumber(1_000)).toBe("1,000");
     });
 
-    it("formats with 2 decimal places", () => {
-      expect(formatNumber(1_234)).toBe("1.23K");
-      expect(formatNumber(9_999)).toBe("10.00K");
-      expect(formatNumber(999_999)).toBe("1000.00K");
-    });
-
-    it("boundary just below 1M", () => {
-      expect(formatNumber(999_999)).toBe("1000.00K");
+    it("formats thousands with commas", () => {
+      expect(formatNumber(1_234)).toBe("1,234");
+      expect(formatNumber(9_999)).toBe("9,999");
+      expect(formatNumber(999_999)).toBe("999,999");
     });
   });
 
-  describe("millions (M)", () => {
+  describe("millions", () => {
     it("formats exactly 1,000,000", () => {
-      expect(formatNumber(1_000_000)).toBe("1.00M");
+      expect(formatNumber(1_000_000)).toBe("1,000,000");
     });
 
-    it("formats with 2 decimal places", () => {
-      expect(formatNumber(4_560_000)).toBe("4.56M");
-      expect(formatNumber(999_999_999)).toBe("1000.00M");
+    it("formats millions with commas", () => {
+      expect(formatNumber(4_560_000)).toBe("4,560,000");
+      expect(formatNumber(999_999_999)).toBe("999,999,999");
     });
   });
 
-  describe("billions (B)", () => {
+  describe("billions", () => {
     it("formats exactly 1,000,000,000", () => {
-      expect(formatNumber(1_000_000_000)).toBe("1.00B");
+      expect(formatNumber(1_000_000_000)).toBe("1,000,000,000");
     });
 
     it("formats large billions", () => {
-      expect(formatNumber(1_500_000_000)).toBe("1.50B");
-      expect(formatNumber(999_000_000_000)).toBe("999.00B");
+      expect(formatNumber(1_500_000_000)).toBe("1,500,000,000");
+      expect(formatNumber(999_000_000_000)).toBe("999,000,000,000");
     });
   });
 
-  describe("trillions (T)", () => {
+  describe("trillions", () => {
     it("formats exactly 1 trillion", () => {
-      expect(formatNumber(1_000_000_000_000)).toBe("1.00T");
+      expect(formatNumber(1_000_000_000_000)).toBe("1,000,000,000,000");
     });
 
-    it("formats with 2 decimal places", () => {
-      expect(formatNumber(4_560_000_000_000)).toBe("4.56T");
-      expect(formatNumber(999_000_000_000_000)).toBe("999.00T");
-    });
-  });
-
-  describe("quadrillions (Qa)", () => {
-    it("formats exactly 1 quadrillion", () => {
-      expect(formatNumber(1_000_000_000_000_000)).toBe("1.00Qa");
-    });
-
-    it("formats with 2 decimal places", () => {
-      expect(formatNumber(2_500_000_000_000_000)).toBe("2.50Qa");
+    it("formats trillions without exponential notation", () => {
+      expect(formatNumber(4_560_000_000_000)).toBe("4,560,000,000,000");
+      expect(formatNumber(999_000_000_000_000)).toBe("999,000,000,000,000");
     });
   });
 
-  describe("quintillions (Qi)", () => {
-    it("formats exactly 1 quintillion", () => {
-      expect(formatNumber(1_000_000_000_000_000_000)).toBe("1.00Qi");
-    });
-
-    it("formats with 2 decimal places", () => {
-      expect(formatNumber(1_500_000_000_000_000_000)).toBe("1.50Qi");
+  describe("very large numbers", () => {
+    it("formats quadrillions without exponential notation", () => {
+      expect(formatNumber(1_000_000_000_000_000)).toBe("1,000,000,000,000,000");
+      expect(formatNumber(2_500_000_000_000_000)).toBe("2,500,000,000,000,000");
     });
   });
 
@@ -101,15 +84,15 @@ describe("formatNumber", () => {
     });
 
     it("formats negative thousands", () => {
-      expect(formatNumber(-1_234)).toBe("-1.23K");
+      expect(formatNumber(-1_234)).toBe("-1,234");
     });
 
     it("formats negative millions", () => {
-      expect(formatNumber(-4_560_000)).toBe("-4.56M");
+      expect(formatNumber(-4_560_000)).toBe("-4,560,000");
     });
 
     it("formats negative billions", () => {
-      expect(formatNumber(-1_000_000_000)).toBe("-1.00B");
+      expect(formatNumber(-1_000_000_000)).toBe("-1,000,000,000");
     });
   });
 

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,49 +1,31 @@
-const SUFFIXES: ReadonlyArray<{ threshold: number; suffix: string }> = [
-  { threshold: 1_000_000_000_000_000_000, suffix: "Qi" },
-  { threshold: 1_000_000_000_000_000, suffix: "Qa" },
-  { threshold: 1_000_000_000_000, suffix: "T" },
-  { threshold: 1_000_000_000, suffix: "B" },
-  { threshold: 1_000_000, suffix: "M" },
-  { threshold: 1_000, suffix: "K" },
-];
-
 /**
- * Format a number with K / M / B / T / Qa / Qi suffixes for compact display.
+ * Format a number with locale-aware comma separators for full display.
  *
- * - Values < 1,000 → plain integer (e.g. "42")
- * - Values >= 1,000 → 2 decimal places + suffix (e.g. "1.23K")
+ * - Values >= 1 → comma-separated integer (e.g. "1,234,567")
+ * - Values between 0 and 1 → 2 decimal places (e.g. "0.50")
  * - Negative values are prefixed with "-" and formatted the same way.
+ * - Very large numbers display cleanly without exponential notation.
  */
 export function formatNumber(n: number): string {
   if (n < 0) {
     return `-${formatNumber(-n)}`;
   }
 
-  for (const { threshold, suffix } of SUFFIXES) {
-    if (n >= threshold) {
-      return `${(n / threshold).toFixed(2)}${suffix}`;
-    }
-  }
-
   if (n > 0 && n < 1) {
     return n.toFixed(2);
   }
 
-  return Math.floor(n).toString();
+  if (n === 0) return "0";
+
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(
+    Math.floor(n),
+  );
 }
 
 /**
  * Format a number with full comma-separated digits (e.g. "1,234,567,890").
- * Used when the player selects "Full" number display mode.
+ * Alias for formatNumber.
  */
 export function formatNumberFull(n: number): string {
-  if (n < 0) {
-    return `-${formatNumberFull(-n)}`;
-  }
-
-  if (n > 0 && n < 1) {
-    return n.toFixed(2);
-  }
-
-  return Math.floor(n).toLocaleString("en-US");
+  return formatNumber(n);
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,1 @@
-export { formatNumber } from "./formatNumber";
+export { formatNumber, formatNumberFull } from "./formatNumber";


### PR DESCRIPTION
## Summary
Replaces all abbreviated number formatting (K/M/B/T/Qa/Qi suffixes) with locale-aware full comma-separated numbers throughout the game UI. Numbers now display as `1,234,567` instead of `1.23M`.

## Changes
- **`formatNumber`**: Rewritten to use `Intl.NumberFormat(undefined, { maximumFractionDigits: 0 })` with the user's locale; values 0–1 retain 2 decimal places; `-0` edge case handled
- **`formatNumberFull`**: Simplified to an alias for `formatNumber` (same output, kept for backward compatibility)
- **`settingsStore`**: Default `numberFormat` changed from `"compact"` to `"full"` so new players see full numbers immediately
- **`PrestigeShop`**: `prestigeTokenBalance` now formatted with `formatNumber` instead of raw integer
- **`utils/index.ts`**: Added `formatNumberFull` to barrel exports
- All call sites of `formatNumber` (StatsBar, StatsPanel, UpgradeCard, ClickUpgradeCard, BoosterCard, FloatingParticles, PetDisplay, RebirthModal, OfflineProgressModal) automatically benefit from the updated formatter — no changes required at call sites

## Tests
- Updated `formatNumber` tests: removed K/M/B/T/Qa/Qi suffix assertions, replaced with comma-formatted equivalents; added "very large numbers" suite verifying no exponential notation
- Updated `settingsStore` test: initial `numberFormat` is now `"full"`
- `formatNumberFull` tests pass unchanged (both functions now produce the same output)
- 475 tests passing, TypeScript clean

## Story
[ux: Display full numbers with comma separators instead of k/M abbreviations](https://github.com/AshDevFr/GLORP/issues/68)

Closes #68

— Devon (4shClaw developer agent)