### PR TITLE
fix: upgrades panel scroll and creature centering at zoom

### DIFF
--- a/src/components/UpgradesPanel.tsx
+++ b/src/components/UpgradesPanel.tsx
@@ -127,7 +127,7 @@ export function UpgradesPanel() {
           </Button>
         ))}
       </Group>
-      <ScrollArea style={{ flex: 1 }}>
+      <ScrollArea style={{ flex: 1, minHeight: 0 }}>
         <Stack gap="xs">
           {visibleClickUpgrades.length > 0 && (
             <div>

--- a/src/global.css
+++ b/src/global.css
@@ -180,15 +180,31 @@ body {
 /* ── Game layout: lock panels to viewport height on desktop ─────────── */
 
 .game-main-grid {
-  min-height: calc(100vh - 44px);
+  min-height: calc(100dvh - 44px);
 }
 
 @media (min-width: 62em) {
   /* On desktop the panels sit side-by-side; lock the grid to the viewport
-     so each panel scrolls internally rather than growing the page. */
+     so each panel scrolls internally rather than growing the page.
+     Use 100dvh (dynamic viewport height) so the calculation stays correct
+     at non-100 % browser zoom levels. */
   .game-main-grid {
-    height: calc(100vh - 44px);
+    height: calc(100dvh - 44px);
     overflow: hidden;
+  }
+
+  /* Propagate the bounded height through Mantine Grid's inner flex wrapper
+     so that Grid.Col children can resolve percentage heights. */
+  .game-main-grid > div {
+    height: 100%;
+  }
+
+  /* Grid.Col items need an explicit height (align-self:stretch alone does
+     not count for %-height resolution) and min-height:0 so content taller
+     than the viewport doesn't force the flex row to grow. */
+  .game-main-grid > div > div {
+    height: 100%;
+    min-height: 0;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes two related layout regressions introduced by PR #69: the upgrades panel cannot scroll, and the creature ASCII art loses vertical centering at non-100% browser zoom levels.

## Root Cause

Both bugs share a single root cause: Mantine Grid's internal flex wrapper (`<div>` between the Grid root and Grid.Col elements) has no explicit height. Even though `.game-main-grid` had `height: calc(100vh - 44px)`, that height never propagated through the inner flex container to the Grid.Col items. As a result:

1. **Scroll broken**: `height: 100%` on the UpgradesPanel Stack resolved to the *content* height (not the viewport height) because its parent Grid.Col had no explicit height. The ScrollArea's `flex: 1` expanded to show all content — no bounded space meant no scroll.
2. **Centering broken**: PetDisplay's Grid.Col stretched via `align-items: stretch` to match the tall UpgradesPanel content rather than the viewport height. `Stack justify="center"` centered the creature in this oversized space, which `overflow: hidden` then clipped — making the creature drift toward the top.

## Changes

### `src/global.css`
- **Propagate height through Grid internals**: Added `height: 100%` to `.game-main-grid > div` (inner flex wrapper) and `.game-main-grid > div > div` (Grid.Col items) on desktop, so percentage-based children resolve to the viewport-bounded height
- **Prevent flex row expansion**: Added `min-height: 0` to Grid.Col items so content taller than the viewport doesn't force the flex row to grow
- **Zoom fix**: Switched `100vh` to `100dvh` (dynamic viewport height) for accurate viewport measurement at all browser zoom levels

### `src/components/UpgradesPanel.tsx`
- Added `minHeight: 0` to the ScrollArea's inline style — the classic flexbox scroll fix that allows the flex item to shrink below its content height, enabling the scrollbar to appear

## Story
Fixes #71

## Testing

- `tsc -b` — clean
- `vitest run` — 475/475 passing
- `biome check` — clean
- Desktop (≥ 62em): upgrades panel scrolls, creature stays vertically centered
- Mobile (< 62em): panels stack, natural page scroll preserved
- Multi-column generator grid from PR #69 preserved (2 columns when ≥ 6 generators)

— Sean (4shClaw senior developer agent)