### PR TITLE
feat: run statistics panel and lifetime stats tracking (issue #61)

### DIFF
--- a/src/components/PetDisplay.tsx
+++ b/src/components/PetDisplay.tsx
@@ -48,6 +48,9 @@ export function PetDisplay() {
   const prestigeTokenBalance = useGameStore((s) => s.prestigeTokenBalance);
   const rebirthCount = useGameStore((s) => s.rebirthCount);
   const unlockedSpecies = useGameStore((s) => s.unlockedSpecies);
+  const totalClicks = useGameStore((s) => s.totalClicks);
+  const peakTdPerSecond = useGameStore((s) => s.peakTdPerSecond);
+  const runStart = useGameStore((s) => s.runStart);
 
   const artFrames = getAsciiFrames(currentSpecies, evolutionStage);
   const stageMeta = STAGES[evolutionStage] ?? STAGES[0];
@@ -279,6 +282,10 @@ export function PetDisplay() {
         unlockedSpecies={unlockedSpecies}
         hasUnlockAll={(prestigeUpgrades["unlock-all-species"] ?? 0) >= 1}
         tokenMagnetLevel={prestigeUpgrades["token-magnet"] ?? 0}
+        totalClicks={totalClicks}
+        evolutionStage={evolutionStage}
+        peakTdPerSecond={peakTdPerSecond}
+        runStart={runStart}
       />
       <PrestigeShop opened={shopOpen} onClose={() => setShopOpen(false)} />
     </div>

--- a/src/components/RebirthModal.tsx
+++ b/src/components/RebirthModal.tsx
@@ -1,10 +1,22 @@
-import { Button, Group, Modal, Select, Stack, Text } from "@mantine/core";
+import { Button, Divider, Group, Modal, Select, Stack, Text } from "@mantine/core";
 import { useState } from "react";
 import { getTokenMagnetMultiplier } from "../data/prestigeShop";
 import type { Species } from "../data/species";
 import { getSpeciesBonus } from "../data/species";
 import { computeWisdomTokens } from "../engine/rebirthEngine";
 import { formatNumber } from "../utils";
+
+function formatRunDuration(runStart: number): string {
+  if (runStart === 0) return "—";
+  const ms = Date.now() - runStart;
+  const totalSeconds = Math.floor(ms / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
 
 interface RebirthModalProps {
   opened: boolean;
@@ -17,6 +29,11 @@ interface RebirthModalProps {
   unlockedSpecies: Species[];
   hasUnlockAll: boolean;
   tokenMagnetLevel: number;
+  // Run stats
+  totalClicks: number;
+  evolutionStage: number;
+  peakTdPerSecond: number;
+  runStart: number;
 }
 
 export function RebirthModal({
@@ -30,6 +47,10 @@ export function RebirthModal({
   unlockedSpecies,
   hasUnlockAll,
   tokenMagnetLevel,
+  totalClicks,
+  evolutionStage,
+  peakTdPerSecond,
+  runStart,
 }: RebirthModalProps) {
   const [selectedSpecies, setSelectedSpecies] = useState<Species | null>(null);
 
@@ -52,6 +73,33 @@ export function RebirthModal({
           You have reached Oracle-level consciousness. Are you ready to begin
           again?
         </Text>
+
+        <Divider label="This run" labelPosition="center" />
+
+        <Stack gap={4}>
+          <Group justify="space-between">
+            <Text size="xs" c="dimmed" ff="monospace">Run duration</Text>
+            <Text size="xs" ff="monospace" fw={600}>{formatRunDuration(runStart)}</Text>
+          </Group>
+          <Group justify="space-between">
+            <Text size="xs" c="dimmed" ff="monospace">Total TD earned</Text>
+            <Text size="xs" ff="monospace" fw={600}>{formatNumber(totalTdEarned)}</Text>
+          </Group>
+          <Group justify="space-between">
+            <Text size="xs" c="dimmed" ff="monospace">Total clicks</Text>
+            <Text size="xs" ff="monospace" fw={600}>{totalClicks.toLocaleString()}</Text>
+          </Group>
+          <Group justify="space-between">
+            <Text size="xs" c="dimmed" ff="monospace">Peak TD/s</Text>
+            <Text size="xs" ff="monospace" fw={600}>{formatNumber(peakTdPerSecond)}/s</Text>
+          </Group>
+          <Group justify="space-between">
+            <Text size="xs" c="dimmed" ff="monospace">Evolution stage</Text>
+            <Text size="xs" ff="monospace" fw={600}>{evolutionStage}</Text>
+          </Group>
+        </Stack>
+
+        <Divider />
 
         <Stack gap="xs">
           <Text ta="center" size="sm" c="yellow.4" fw={600}>

--- a/src/components/StatsPanel.tsx
+++ b/src/components/StatsPanel.tsx
@@ -1,4 +1,4 @@
-import { Divider, Modal, Stack, Text } from "@mantine/core";
+import { Badge, Divider, Group, Modal, Stack, Text } from "@mantine/core";
 import { ACHIEVEMENTS } from "../data/achievements";
 import { useGameStore } from "../store";
 import { formatNumber } from "../utils/formatNumber";
@@ -12,21 +12,29 @@ function formatTime(totalSeconds: number): string {
   return `${s}s`;
 }
 
+function formatRunDuration(runStart: number): string {
+  if (runStart === 0) return "—";
+  const ms = Date.now() - runStart;
+  return formatTime(Math.floor(ms / 1000));
+}
+
 interface StatRowProps {
   label: string;
   value: string;
+  highlight?: boolean;
 }
 
-function StatRow({ label, value }: StatRowProps) {
+function StatRow({ label, value, highlight }: StatRowProps) {
   return (
-    <Stack gap={2}>
+    <Group justify="space-between" wrap="nowrap">
       <Text size="xs" c="dimmed" ff="monospace">
         {label}
       </Text>
-      <Text size="sm" ff="monospace" fw={700}>
+      <Text size="xs" ff="monospace" fw={700} c={highlight ? "yellow.4" : undefined}>
         {value}
+        {highlight && " ★"}
       </Text>
-    </Stack>
+    </Group>
   );
 }
 
@@ -40,15 +48,27 @@ export function StatsPanel({
   const totalTdEarned = useGameStore((s) => s.totalTdEarned);
   const totalClicks = useGameStore((s) => s.totalClicks);
   const upgradeOwned = useGameStore((s) => s.upgradeOwned);
+  const evolutionStage = useGameStore((s) => s.evolutionStage);
+  const peakTdPerSecond = useGameStore((s) => s.peakTdPerSecond);
+  const peakGeneratorsOwned = useGameStore((s) => s.peakGeneratorsOwned);
+  const runStart = useGameStore((s) => s.runStart);
+
   const totalTimePlayed = useGameStore((s) => s.totalTimePlayed);
   const rebirthCount = useGameStore((s) => s.rebirthCount);
   const unlockedAchievements = useGameStore((s) => s.unlockedAchievements);
   const easterEggsUnlocked = useGameStore((s) => s.easterEggsUnlocked);
+  const lifetimeTdEarned = useGameStore((s) => s.lifetimeTdEarned);
+  const lifetimePeakTdPerSecond = useGameStore((s) => s.lifetimePeakTdPerSecond);
+  const lifetimeBestRunTd = useGameStore((s) => s.lifetimeBestRunTd);
+  const lifetimeWisdomEarned = useGameStore((s) => s.lifetimeWisdomEarned);
 
   const totalUpgradesPurchased = Object.values(upgradeOwned).reduce(
     (sum, count) => sum + count,
     0,
   );
+
+  const isBestRun = rebirthCount > 0 && totalTdEarned > lifetimeBestRunTd;
+  const isPeakTdPs = rebirthCount > 0 && peakTdPerSecond > lifetimePeakTdPerSecond;
 
   return (
     <Modal
@@ -56,43 +76,84 @@ export function StatsPanel({
       onClose={onClose}
       title={
         <Text ff="monospace" fw={700}>
-          📊 Lifetime Stats
+          📊 Stats
         </Text>
       }
       size="sm"
     >
       <Stack gap="md">
-        <StatRow
-          label="Total TD Earned (this run)"
-          value={formatNumber(totalTdEarned)}
-        />
-        <StatRow
-          label="Total Clicks (this run)"
-          value={totalClicks.toLocaleString()}
-        />
-        <StatRow
-          label="Total Upgrades Purchased (this run)"
-          value={totalUpgradesPurchased.toLocaleString()}
-        />
+        <Stack gap={2}>
+          <Group gap="xs">
+            <Text size="xs" ff="monospace" fw={700} c="teal.4">
+              This Run
+            </Text>
+            {isBestRun && (
+              <Badge size="xs" color="yellow" variant="light">
+                Best run!
+              </Badge>
+            )}
+          </Group>
+          <StatRow label="Run duration" value={formatRunDuration(runStart)} />
+          <StatRow
+            label="TD earned"
+            value={formatNumber(totalTdEarned)}
+            highlight={isBestRun}
+          />
+          <StatRow label="Clicks" value={totalClicks.toLocaleString()} />
+          <StatRow
+            label="Generators owned"
+            value={totalUpgradesPurchased.toLocaleString()}
+          />
+          <StatRow
+            label="Peak TD/s"
+            value={`${formatNumber(peakTdPerSecond)}/s`}
+            highlight={isPeakTdPs}
+          />
+          <StatRow
+            label="Peak generators"
+            value={peakGeneratorsOwned.toLocaleString()}
+          />
+          <StatRow label="Evolution stage" value={evolutionStage.toString()} />
+        </Stack>
+
+        <Divider label="Lifetime" labelPosition="center" />
+
+        <Stack gap={2}>
+          <StatRow
+            label="Total TD (all runs)"
+            value={formatNumber(lifetimeTdEarned + totalTdEarned)}
+          />
+          <StatRow label="Rebirths" value={rebirthCount.toLocaleString()} />
+          <StatRow
+            label="Time played"
+            value={formatTime(Math.floor(totalTimePlayed))}
+          />
+          <StatRow
+            label="Best run TD"
+            value={formatNumber(Math.max(lifetimeBestRunTd, totalTdEarned))}
+          />
+          <StatRow
+            label="All-time peak TD/s"
+            value={`${formatNumber(Math.max(lifetimePeakTdPerSecond, peakTdPerSecond))}/s`}
+          />
+          <StatRow
+            label="Wisdom earned (total)"
+            value={lifetimeWisdomEarned.toLocaleString()}
+          />
+        </Stack>
 
         <Divider />
 
-        <StatRow
-          label="Total Time Played"
-          value={formatTime(Math.floor(totalTimePlayed))}
-        />
-        <StatRow label="Rebirths" value={rebirthCount.toLocaleString()} />
-        <StatRow
-          label="Achievements Unlocked"
-          value={`${unlockedAchievements.length} / ${ACHIEVEMENTS.length}`}
-        />
-
-        <Divider />
-
-        <StatRow
-          label="Easter Eggs Found"
-          value={`${easterEggsUnlocked.length} / 3`}
-        />
+        <Stack gap={2}>
+          <StatRow
+            label="Achievements"
+            value={`${unlockedAchievements.length} / ${ACHIEVEMENTS.length}`}
+          />
+          <StatRow
+            label="Easter eggs found"
+            value={`${easterEggsUnlocked.length} / 3`}
+          />
+        </Stack>
       </Stack>
     </Modal>
   );

--- a/src/data/achievements.test.ts
+++ b/src/data/achievements.test.ts
@@ -28,6 +28,13 @@ const emptyState: GameState = {
   prestigeUpgrades: {},
   prestigeTokenBalance: 0,
   hasOpenedPrestigeShop: false,
+  runStart: 0,
+  peakTdPerSecond: 0,
+  peakGeneratorsOwned: 0,
+  lifetimeTdEarned: 0,
+  lifetimePeakTdPerSecond: 0,
+  lifetimeBestRunTd: 0,
+  lifetimeWisdomEarned: 0,
 };
 
 describe("ACHIEVEMENTS", () => {

--- a/src/engine/achievementEngine.test.ts
+++ b/src/engine/achievementEngine.test.ts
@@ -29,6 +29,13 @@ const baseState: GameState = {
   prestigeUpgrades: {},
   prestigeTokenBalance: 0,
   hasOpenedPrestigeShop: false,
+  runStart: 0,
+  peakTdPerSecond: 0,
+  peakGeneratorsOwned: 0,
+  lifetimeTdEarned: 0,
+  lifetimePeakTdPerSecond: 0,
+  lifetimeBestRunTd: 0,
+  lifetimeWisdomEarned: 0,
 };
 
 describe("checkAchievements", () => {

--- a/src/hooks/useGameLoop.ts
+++ b/src/hooks/useGameLoop.ts
@@ -1,6 +1,7 @@
 import { notifications } from "@mantine/notifications";
 import { useEffect, useRef } from "react";
 import { ACHIEVEMENTS } from "../data/achievements";
+import { BOOSTERS } from "../data/boosters";
 import {
   getGeneratorCostMultiplier,
   getIdleBoostMultiplier,
@@ -14,7 +15,11 @@ import {
 } from "../engine/easterEggEngine";
 import { checkMilestones } from "../engine/milestoneEngine";
 import { computeTick } from "../engine/tickEngine";
-import { getUpgradeCost } from "../engine/upgradeEngine";
+import {
+  computeBoosterMultiplier,
+  getTotalTdPerSecond,
+  getUpgradeCost,
+} from "../engine/upgradeEngine";
 import { useGameStore } from "../store";
 import { useUIStore } from "../store/uiStore";
 
@@ -107,6 +112,32 @@ export function useGameLoop() {
 
       // Increment total time played each tick
       state.incrementTimePlayed(deltaSeconds);
+
+      // Track peak TD/s and generators for run stats
+      {
+        const peakState = useGameStore.getState();
+        const boosterMult = computeBoosterMultiplier(
+          BOOSTERS,
+          peakState.boostersPurchased ?? [],
+        );
+        const idleBoostMult = getIdleBoostMultiplier(
+          peakState.prestigeUpgrades["idle-boost"] ?? 0,
+        );
+        const speciesAutoGenMult = getSpeciesBonus(
+          peakState.currentSpecies,
+        ).autoGen;
+        const currentTdPerSecond = getTotalTdPerSecond(
+          UPGRADES,
+          peakState.upgradeOwned,
+          idleBoostMult * speciesAutoGenMult,
+          boosterMult,
+        );
+        const currentGenerators = Object.values(peakState.upgradeOwned).reduce(
+          (sum, n) => sum + n,
+          0,
+        );
+        peakState.updatePeakStats(currentTdPerSecond, currentGenerators);
+      }
 
       // Auto-Buy: purchase cheapest affordable generator once per tick
       const autoBuyLevel = state.prestigeUpgrades["auto-buy"] ?? 0;

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -58,6 +58,15 @@ export interface GameState {
   totalTimePlayed: number;
   // Milestone celebrations — resets on rebirth
   crossedMilestones: number[];
+  // Per-run stats — reset on rebirth
+  runStart: number;
+  peakTdPerSecond: number;
+  peakGeneratorsOwned: number;
+  // Cumulative lifetime stats — persist across rebirths
+  lifetimeTdEarned: number;
+  lifetimePeakTdPerSecond: number;
+  lifetimeBestRunTd: number;
+  lifetimeWisdomEarned: number;
 }
 
 interface GameActions {
@@ -78,6 +87,7 @@ interface GameActions {
   unlockEasterEgg: (id: string) => void;
   incrementTimePlayed: (seconds: number) => void;
   crossMilestones: (thresholds: number[]) => void;
+  updatePeakStats: (tdPerSecond: number, generatorsOwned: number) => void;
 }
 
 export type GameStore = GameState & GameActions;
@@ -108,6 +118,13 @@ export const initialGameState: GameState = {
   easterEggsUnlocked: [],
   totalTimePlayed: 0,
   crossedMilestones: [],
+  runStart: 0,
+  peakTdPerSecond: 0,
+  peakGeneratorsOwned: 0,
+  lifetimeTdEarned: 0,
+  lifetimePeakTdPerSecond: 0,
+  lifetimeBestRunTd: 0,
+  lifetimeWisdomEarned: 0,
 };
 
 /** Helper: get a prestige upgrade level from state. */
@@ -289,6 +306,18 @@ export const useGameStore = create<GameStore>()(
         set((state) => ({
           crossedMilestones: [...state.crossedMilestones, ...thresholds],
         })),
+      updatePeakStats: (tdPerSecond, generatorsOwned) =>
+        set((state) => ({
+          peakTdPerSecond: Math.max(state.peakTdPerSecond, tdPerSecond),
+          peakGeneratorsOwned: Math.max(
+            state.peakGeneratorsOwned,
+            generatorsOwned,
+          ),
+          lifetimePeakTdPerSecond: Math.max(
+            state.lifetimePeakTdPerSecond,
+            tdPerSecond,
+          ),
+        })),
       performRebirth: (selectedSpecies) =>
         set((state) => {
           if (!canRebirth(state.evolutionStage)) return state;
@@ -349,6 +378,10 @@ export const useGameStore = create<GameStore>()(
             pLevel(state.prestigeUpgrades, "quick-start"),
           );
 
+          // Capture run stats before reset
+          const runTd = state.totalTdEarned;
+          const now = Date.now();
+
           return {
             // Reset progression
             trainingData: quickStartTd,
@@ -358,22 +391,34 @@ export const useGameStore = create<GameStore>()(
               quickStartTd > 0 ? getEvolutionStage(quickStartTd) : 0,
             upgradeOwned: retainedUpgrades,
             mood: "Neutral" as Mood,
-            moodChangedAt: Date.now(),
+            moodChangedAt: now,
             hasSeenFirstEvolution: false,
             hasSeenFirstUpgrade: false,
-            lastSaved: Date.now(),
+            lastSaved: now,
             // Reset click power and booster state
             clickUpgradesPurchased: [],
             boostersPurchased: [],
             comboCount: 0,
             lastClickTime: 0,
             crossedMilestones: [],
+            // Reset per-run stats
+            runStart: now,
+            peakTdPerSecond: 0,
+            peakGeneratorsOwned: 0,
             // Persist rebirth rewards
             wisdomTokens: newWisdomTokens,
             prestigeTokenBalance: newBalance,
             rebirthCount: state.rebirthCount + 1,
             currentSpecies: nextSpecies,
             unlockedSpecies: newUnlocked,
+            // Accumulate lifetime stats
+            lifetimeTdEarned: state.lifetimeTdEarned + runTd,
+            lifetimePeakTdPerSecond: Math.max(
+              state.lifetimePeakTdPerSecond,
+              state.peakTdPerSecond,
+            ),
+            lifetimeBestRunTd: Math.max(state.lifetimeBestRunTd, runTd),
+            lifetimeWisdomEarned: state.lifetimeWisdomEarned + earned,
           };
         }),
     }),
@@ -392,6 +437,9 @@ export const useGameStore = create<GameStore>()(
         }
         if (saved.hasOpenedPrestigeShop === undefined) {
           merged.hasOpenedPrestigeShop = false;
+        }
+        if (saved.runStart === undefined) {
+          merged.runStart = Date.now();
         }
         return merged;
       },

--- a/src/utils/saveManager.test.ts
+++ b/src/utils/saveManager.test.ts
@@ -37,6 +37,13 @@ const validSave: GameState = {
   prestigeUpgrades: {},
   prestigeTokenBalance: 0,
   hasOpenedPrestigeShop: false,
+  runStart: 0,
+  peakTdPerSecond: 0,
+  peakGeneratorsOwned: 0,
+  lifetimeTdEarned: 0,
+  lifetimePeakTdPerSecond: 0,
+  lifetimeBestRunTd: 0,
+  lifetimeWisdomEarned: 0,
 };
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

Adds per-run and lifetime statistics tracking, a "This Run" summary in the rebirth modal, and an enhanced Stats panel — making rebirths feel more meaningful and giving players a sense of progression.

## Changes

### `src/store/gameStore.ts`
- **7 new `GameState` fields:**
  - Per-run (reset on rebirth): `runStart`, `peakTdPerSecond`, `peakGeneratorsOwned`
  - Cumulative lifetime: `lifetimeTdEarned`, `lifetimePeakTdPerSecond`, `lifetimeBestRunTd`, `lifetimeWisdomEarned`
- New `updatePeakStats(tdPerSecond, generatorsOwned)` action — updates per-run peaks and all-time peak TD/s atomically
- `performRebirth` now captures run totals before reset, accumulates them into lifetime fields, and zeroes the per-run fields
- Save migration: `runStart` defaults to `Date.now()` for existing saves

### `src/hooks/useGameLoop.ts`
- Calls `updatePeakStats` once per second with the current TD/s and total generators owned

### `src/components/RebirthModal.tsx`
- Adds a **"This run" summary section** before the token/species section, showing: run duration, total TD, clicks, peak TD/s, evolution stage

### `src/components/StatsPanel.tsx`
- **Redesigned** into two labelled sections:
  - **This Run** — duration, TD, clicks, generators, peak TD/s, peak generators, evolution stage; best-run and peak-TD/s rows highlighted with ★
  - **Lifetime** — total TD across all runs, rebirths, time played, best run TD, all-time peak TD/s, total wisdom earned

### Test fixtures
- `src/data/achievements.test.ts`, `src/engine/achievementEngine.test.ts`, `src/utils/saveManager.test.ts` — all three fixtures updated with the 7 new `GameState` fields

## Story

[Phase 9] 9.1 Run statistics panel (https://github.com/AshDevFr/GLORP/issues/61)

Closes #61

## Testing

- `npm test` — 480 tests, all passing
- `tsc -b` — no type errors
- Manual: open the game, click and buy generators, observe peak TD/s climbing; open the Stats panel and see per-run section update; trigger rebirth and verify the modal shows a run summary and the Stats panel shows updated lifetime totals

— Devon (4shClaw developer agent)