### PR TITLE
fix: scale click power with passive income (issue #73)

### DIFF
--- a/src/components/PetDisplay.tsx
+++ b/src/components/PetDisplay.tsx
@@ -1,10 +1,15 @@
 import { Badge, Button, Group, Stack, Text } from "@mantine/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getAsciiFrames } from "../data/asciiArt";
+import { BOOSTERS } from "../data/boosters";
 import { CLICK_UPGRADES } from "../data/clickUpgrades";
-import { getClickMasteryBonus } from "../data/prestigeShop";
+import {
+  getClickMasteryBonus,
+  getIdleBoostMultiplier,
+} from "../data/prestigeShop";
 import { getSpeciesBonus } from "../data/species";
 import { STAGES } from "../data/stages";
+import { UPGRADES } from "../data/upgrades";
 import {
   COMBO_DECAY_MS,
   COMBO_THRESHOLD,
@@ -13,6 +18,10 @@ import {
 } from "../engine/clickEngine";
 import { getClickMood } from "../engine/moodEngine";
 import { canRebirth, getNextSpecies } from "../engine/rebirthEngine";
+import {
+  computeBoosterMultiplier,
+  getTotalTdPerSecond,
+} from "../engine/upgradeEngine";
 import { useAsciiAnimation } from "../hooks/useAsciiAnimation";
 import { useClickParticles } from "../hooks/useClickParticles";
 import { useDialogue } from "../hooks/useDialogue";
@@ -51,6 +60,8 @@ export function PetDisplay() {
   const totalClicks = useGameStore((s) => s.totalClicks);
   const peakTdPerSecond = useGameStore((s) => s.peakTdPerSecond);
   const runStart = useGameStore((s) => s.runStart);
+  const upgradeOwned = useGameStore((s) => s.upgradeOwned);
+  const boostersPurchased = useGameStore((s) => s.boostersPurchased);
 
   const artFrames = getAsciiFrames(currentSpecies, evolutionStage);
   const stageMeta = STAGES[evolutionStage] ?? STAGES[0];
@@ -106,18 +117,26 @@ export function PetDisplay() {
   const clickMastery = getClickMasteryBonus(
     prestigeUpgrades["click-mastery"] ?? 0,
   );
-  const speciesClickPower = getSpeciesBonus(currentSpecies).clickPower;
+  const speciesBonus = getSpeciesBonus(currentSpecies);
+  const idleBoost = getIdleBoostMultiplier(prestigeUpgrades["idle-boost"] ?? 0);
+  const boosterMult = computeBoosterMultiplier(BOOSTERS, boostersPurchased);
+  const currentTdPerSecond = getTotalTdPerSecond(
+    UPGRADES,
+    upgradeOwned,
+    idleBoost * speciesBonus.autoGen,
+    boosterMult,
+  );
   const baseClickPower = computeClickPower(
     {
-      evolutionStage,
       clickUpgradesPurchased,
       comboCount: 0,
       lastClickTime: 0,
     },
     CLICK_UPGRADES,
-    Date.now(),
+    currentTdPerSecond,
+    undefined,
     clickMastery,
-    speciesClickPower,
+    speciesBonus.clickPower,
   );
 
   // Decay combo display when not clicking

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -1,9 +1,14 @@
 import { Group, Text } from "@mantine/core";
 import { useEffect, useRef, useState } from "react";
 import { BOOSTERS } from "../data/boosters";
-import { getIdleBoostMultiplier } from "../data/prestigeShop";
+import { CLICK_UPGRADES } from "../data/clickUpgrades";
+import {
+  getClickMasteryBonus,
+  getIdleBoostMultiplier,
+} from "../data/prestigeShop";
 import { getSpeciesBonus } from "../data/species";
 import { UPGRADES } from "../data/upgrades";
+import { computeClickPower } from "../engine/clickEngine";
 import {
   computeBoosterMultiplier,
   getTotalTdPerSecond,
@@ -23,8 +28,11 @@ export function StatsBar() {
   const prestigeUpgrades = useGameStore((s) => s.prestigeUpgrades);
   const currentSpecies = useGameStore((s) => s.currentSpecies);
   const rebirthCount = useGameStore((s) => s.rebirthCount);
+  const clickUpgradesPurchased = useGameStore((s) => s.clickUpgradesPurchased);
+  const comboCount = useGameStore((s) => s.comboCount);
+  const lastClickTime = useGameStore((s) => s.lastClickTime);
   const idleBoost = getIdleBoostMultiplier(prestigeUpgrades["idle-boost"] ?? 0);
-  const speciesAutoGen = getSpeciesBonus(currentSpecies).autoGen;
+  const speciesBonus = getSpeciesBonus(currentSpecies);
   const boosterMultiplier = computeBoosterMultiplier(
     BOOSTERS,
     boostersPurchased,
@@ -32,8 +40,19 @@ export function StatsBar() {
   const tdPerSecond = getTotalTdPerSecond(
     UPGRADES,
     upgradeOwned,
-    idleBoost * speciesAutoGen,
+    idleBoost * speciesBonus.autoGen,
     boosterMultiplier,
+  );
+  const clickMastery = getClickMasteryBonus(
+    prestigeUpgrades["click-mastery"] ?? 0,
+  );
+  const effectiveClickPower = computeClickPower(
+    { clickUpgradesPurchased, comboCount, lastClickTime },
+    CLICK_UPGRADES,
+    tdPerSecond,
+    undefined,
+    clickMastery,
+    speciesBonus.clickPower,
   );
   const numberFormat = useSettingsStore((s) => s.numberFormat);
   const fmt = numberFormat === "full" ? formatNumberFull : formatNumber;
@@ -89,6 +108,12 @@ export function StatsBar() {
             ▲✦
           </Text>
         )}
+      </Text>
+      <Text size="sm" ff="monospace">
+        Click:{" "}
+        <Text span fw={700} c="cyan">
+          {fmt(Math.floor(effectiveClickPower))} TD
+        </Text>
       </Text>
       {rebirthCount > 0 && (
         <Text size="sm" ff="monospace">

--- a/src/components/upgrades/ClickUpgradeCard.tsx
+++ b/src/components/upgrades/ClickUpgradeCard.tsx
@@ -69,7 +69,7 @@ export function ClickUpgradeCard({
 
       <Group justify="space-between" align="center">
         <Text size="xs" ff="monospace" c="yellow">
-          {upgrade.multiplier}x click power
+          +{upgrade.clickSeconds}s per click
         </Text>
         {!purchased && (
           <Button

--- a/src/data/clickUpgrades.ts
+++ b/src/data/clickUpgrades.ts
@@ -2,7 +2,8 @@ export interface ClickUpgrade {
   id: string;
   name: string;
   description: string;
-  multiplier: number;
+  /** Seconds of passive income added to each click when this upgrade is owned. */
+  clickSeconds: number;
   cost: number;
   unlockStage: number;
   icon: string;
@@ -13,8 +14,8 @@ export const CLICK_UPGRADES: readonly ClickUpgrade[] = [
     id: "better-dataset",
     name: "Better Dataset",
     description:
-      "Higher quality training samples make each click count double.",
-    multiplier: 2,
+      "Higher quality training samples — each click earns +0.10s of passive income.",
+    clickSeconds: 0.1,
     cost: 10,
     unlockStage: 0,
     icon: "📊",
@@ -22,8 +23,9 @@ export const CLICK_UPGRADES: readonly ClickUpgrade[] = [
   {
     id: "stack-overflow",
     name: "Stack Overflow",
-    description: "Copy-paste wisdom from the internet. 2x click power.",
-    multiplier: 2,
+    description:
+      "Copy-paste wisdom from the internet. Each click earns +0.15s of passive income.",
+    clickSeconds: 0.15,
     cost: 1_000,
     unlockStage: 0,
     icon: "📚",
@@ -32,8 +34,8 @@ export const CLICK_UPGRADES: readonly ClickUpgrade[] = [
     id: "fine-tuning-lab",
     name: "Fine-Tuning Lab",
     description:
-      "Specialized facility to fine-tune each manual input. 3x click power.",
-    multiplier: 3,
+      "Specialized facility to fine-tune each manual input. +0.25s per click.",
+    clickSeconds: 0.25,
     cost: 50_000,
     unlockStage: 1,
     icon: "🔧",
@@ -42,8 +44,8 @@ export const CLICK_UPGRADES: readonly ClickUpgrade[] = [
     id: "rlhf-department",
     name: "RLHF Department",
     description:
-      "A whole department of humans reinforcing your learning. 5x click power.",
-    multiplier: 5,
+      "A whole department of humans reinforcing your learning. +0.50s per click.",
+    clickSeconds: 0.5,
     cost: 5_000_000,
     unlockStage: 2,
     icon: "👥",
@@ -52,8 +54,8 @@ export const CLICK_UPGRADES: readonly ClickUpgrade[] = [
     id: "synthetic-data-farm",
     name: "Synthetic Data Farm",
     description:
-      "Generate perfect synthetic training data on every click. 10x click power.",
-    multiplier: 10,
+      "Generate perfect synthetic training data on every click. +1.00s per click.",
+    clickSeconds: 1.0,
     cost: 500_000_000,
     unlockStage: 3,
     icon: "🏭",

--- a/src/engine/clickEngine.test.ts
+++ b/src/engine/clickEngine.test.ts
@@ -2,21 +2,26 @@ import { describe, expect, it } from "vitest";
 import type { ClickUpgrade } from "../data/clickUpgrades";
 import { CLICK_UPGRADES } from "../data/clickUpgrades";
 import {
+  BASE_CLICK_SECONDS,
   COMBO_CLICK_WINDOW_MS,
   COMBO_DECAY_MS,
   COMBO_MULTIPLIER,
   COMBO_THRESHOLD,
   computeClickPower,
+  computeClickSeconds,
   computeComboMultiplier,
   getNextComboCount,
+  MASTERY_CLICK_SECONDS_PER_LEVEL,
 } from "./clickEngine";
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
 
 const mockUpgrades: readonly ClickUpgrade[] = [
   {
     id: "upgrade-a",
     name: "Upgrade A",
     description: "Test",
-    multiplier: 2,
+    clickSeconds: 0.1,
     cost: 10,
     unlockStage: 0,
     icon: "A",
@@ -25,7 +30,7 @@ const mockUpgrades: readonly ClickUpgrade[] = [
     id: "upgrade-b",
     name: "Upgrade B",
     description: "Test",
-    multiplier: 3,
+    clickSeconds: 0.15,
     cost: 100,
     unlockStage: 0,
     icon: "B",
@@ -34,166 +39,176 @@ const mockUpgrades: readonly ClickUpgrade[] = [
     id: "upgrade-c",
     name: "Upgrade C",
     description: "Test",
-    multiplier: 5,
+    clickSeconds: 0.25,
     cost: 1000,
     unlockStage: 1,
     icon: "C",
   },
 ];
 
+const NO_COMBO = { comboCount: 0, lastClickTime: 0 };
+
+// ── computeClickSeconds ───────────────────────────────────────────────────────
+
+describe("computeClickSeconds", () => {
+  it("returns BASE_CLICK_SECONDS with no upgrades or mastery", () => {
+    expect(computeClickSeconds([], mockUpgrades)).toBe(BASE_CLICK_SECONDS);
+  });
+
+  it("adds clickSeconds for each purchased upgrade", () => {
+    expect(computeClickSeconds(["upgrade-a"], mockUpgrades)).toBeCloseTo(
+      BASE_CLICK_SECONDS + 0.1,
+    );
+  });
+
+  it("stacks multiple purchased upgrades", () => {
+    expect(
+      computeClickSeconds(
+        ["upgrade-a", "upgrade-b", "upgrade-c"],
+        mockUpgrades,
+      ),
+    ).toBeCloseTo(BASE_CLICK_SECONDS + 0.1 + 0.15 + 0.25);
+  });
+
+  it("adds MASTERY_CLICK_SECONDS_PER_LEVEL per mastery level", () => {
+    expect(computeClickSeconds([], mockUpgrades, 3)).toBeCloseTo(
+      BASE_CLICK_SECONDS + 3 * MASTERY_CLICK_SECONDS_PER_LEVEL,
+    );
+  });
+
+  it("ignores non-existent upgrade IDs", () => {
+    expect(computeClickSeconds(["nonexistent"], mockUpgrades)).toBe(
+      BASE_CLICK_SECONDS,
+    );
+  });
+});
+
+// ── computeClickPower ─────────────────────────────────────────────────────────
+
 describe("computeClickPower", () => {
-  it("returns 1 at base state (stage 0, no upgrades, no combo)", () => {
+  it("returns 1 (floor) when tdPerSecond is 0 and no combo", () => {
     const power = computeClickPower(
-      {
-        evolutionStage: 0,
-        clickUpgradesPurchased: [],
-        comboCount: 0,
-        lastClickTime: 0,
-      },
+      { clickUpgradesPurchased: [], ...NO_COMBO },
       mockUpgrades,
-      Date.now(),
+      0,
     );
     expect(power).toBe(1);
   });
 
-  it("scales with evolution stage: (1 + stage)", () => {
+  it("returns floor of 1 even with upgrades at 0 tdPerSecond", () => {
     const power = computeClickPower(
-      {
-        evolutionStage: 3,
-        clickUpgradesPurchased: [],
-        comboCount: 0,
-        lastClickTime: 0,
-      },
+      { clickUpgradesPurchased: ["upgrade-a"], ...NO_COMBO },
       mockUpgrades,
-      Date.now(),
+      0,
     );
-    expect(power).toBe(4); // 1 + 3 = 4
+    expect(power).toBe(1);
   });
 
-  it("at Singularity (stage 5), base is 6x before upgrades", () => {
+  it("scales linearly with tdPerSecond", () => {
+    const tdPerSecond = 1000;
     const power = computeClickPower(
-      {
-        evolutionStage: 5,
-        clickUpgradesPurchased: [],
-        comboCount: 0,
-        lastClickTime: 0,
-      },
+      { clickUpgradesPurchased: [], ...NO_COMBO },
       mockUpgrades,
-      Date.now(),
+      tdPerSecond,
     );
-    expect(power).toBe(6); // 1 + 5 = 6
+    expect(power).toBeCloseTo(BASE_CLICK_SECONDS * tdPerSecond);
   });
 
-  it("multiplies by purchased click upgrades", () => {
+  it("adds purchased upgrade seconds to base", () => {
+    const tdPerSecond = 1000;
+    const expected = (BASE_CLICK_SECONDS + 0.1) * tdPerSecond; // upgrade-a
     const power = computeClickPower(
-      {
-        evolutionStage: 0,
-        clickUpgradesPurchased: ["upgrade-a"],
-        comboCount: 0,
-        lastClickTime: 0,
-      },
+      { clickUpgradesPurchased: ["upgrade-a"], ...NO_COMBO },
       mockUpgrades,
-      Date.now(),
+      tdPerSecond,
     );
-    expect(power).toBe(2); // 1 * 2 = 2
+    expect(power).toBeCloseTo(expected);
   });
 
-  it("stacks multiple upgrade multipliers", () => {
+  it("stacks all purchased upgrades", () => {
+    const tdPerSecond = 100;
+    const totalSeconds = BASE_CLICK_SECONDS + 0.1 + 0.15 + 0.25;
     const power = computeClickPower(
       {
-        evolutionStage: 0,
         clickUpgradesPurchased: ["upgrade-a", "upgrade-b", "upgrade-c"],
-        comboCount: 0,
-        lastClickTime: 0,
+        ...NO_COMBO,
       },
       mockUpgrades,
-      Date.now(),
+      tdPerSecond,
     );
-    expect(power).toBe(30); // 1 * 2 * 3 * 5 = 30
+    expect(power).toBeCloseTo(totalSeconds * tdPerSecond);
   });
 
-  it("combines evolution stage and upgrades", () => {
-    const power = computeClickPower(
-      {
-        evolutionStage: 2,
-        clickUpgradesPurchased: ["upgrade-a"],
-        comboCount: 0,
-        lastClickTime: 0,
-      },
-      mockUpgrades,
-      Date.now(),
-    );
-    expect(power).toBe(6); // (1+2) * 2 = 6
-  });
-
-  it("applies combo multiplier when combo is active", () => {
+  it("applies combo multiplier on top", () => {
     const now = Date.now();
+    const tdPerSecond = 1000;
     const power = computeClickPower(
       {
-        evolutionStage: 0,
         clickUpgradesPurchased: [],
         comboCount: COMBO_THRESHOLD,
         lastClickTime: now,
       },
       mockUpgrades,
+      tdPerSecond,
       now,
     );
-    expect(power).toBe(COMBO_MULTIPLIER); // 1 * 1.5 = 1.5
+    const expectedBase = BASE_CLICK_SECONDS * tdPerSecond;
+    expect(power).toBeCloseTo(expectedBase * COMBO_MULTIPLIER);
   });
 
-  it("combines all three: stage + upgrades + combo", () => {
-    const now = Date.now();
-    const comboCount = COMBO_THRESHOLD + 5;
-    const expectedCombo = computeComboMultiplier(comboCount, now, now);
+  it("applies species click multiplier", () => {
+    const tdPerSecond = 1000;
     const power = computeClickPower(
-      {
-        evolutionStage: 5,
-        clickUpgradesPurchased: ["upgrade-a", "upgrade-b"],
-        comboCount,
-        lastClickTime: now,
-      },
+      { clickUpgradesPurchased: [], ...NO_COMBO },
       mockUpgrades,
-      now,
+      tdPerSecond,
+      undefined,
+      0,
+      1.5, // CHONK species
     );
-    // (1+5) * 2 * 3 * expectedCombo = 36 * expectedCombo
-    expect(power).toBeCloseTo(36 * expectedCombo, 5);
+    expect(power).toBeCloseTo(BASE_CLICK_SECONDS * tdPerSecond * 1.5);
   });
 
-  it("ignores non-existent upgrade IDs", () => {
+  it("includes click mastery bonus seconds", () => {
+    const tdPerSecond = 1000;
+    const masteryLevel = 5;
+    const expected =
+      (BASE_CLICK_SECONDS + masteryLevel * MASTERY_CLICK_SECONDS_PER_LEVEL) *
+      tdPerSecond;
     const power = computeClickPower(
-      {
-        evolutionStage: 0,
-        clickUpgradesPurchased: ["nonexistent-id"],
-        comboCount: 0,
-        lastClickTime: 0,
-      },
+      { clickUpgradesPurchased: [], ...NO_COMBO },
       mockUpgrades,
-      Date.now(),
+      tdPerSecond,
+      undefined,
+      masteryLevel,
     );
-    expect(power).toBe(1);
+    expect(power).toBeCloseTo(expected);
   });
 
-  it("works with real CLICK_UPGRADES data — all purchased at stage 5", () => {
+  it("click power scales with tdPerSecond — mid game example", () => {
+    // At 1,000 TD/s with all real upgrades → ~2.05s × 1000 = 2050 TD/click
     const allIds = CLICK_UPGRADES.map((u) => u.id);
-    const totalMultiplier = CLICK_UPGRADES.reduce(
-      (acc, u) => acc * u.multiplier,
-      1,
-    );
     const power = computeClickPower(
-      {
-        evolutionStage: 5,
-        clickUpgradesPurchased: allIds,
-        comboCount: 0,
-        lastClickTime: 0,
-      },
+      { clickUpgradesPurchased: allIds, ...NO_COMBO },
       CLICK_UPGRADES,
-      Date.now(),
+      1000,
     );
-    // (1+5) * 600 = 3600
-    expect(power).toBe(6 * totalMultiplier);
-    expect(totalMultiplier).toBe(600);
+    expect(power).toBeGreaterThan(1000);
+  });
+
+  it("click power scales with tdPerSecond — late game example", () => {
+    // At 30,000 TD/s with all real upgrades → >60,000 TD/click
+    const allIds = CLICK_UPGRADES.map((u) => u.id);
+    const power = computeClickPower(
+      { clickUpgradesPurchased: allIds, ...NO_COMBO },
+      CLICK_UPGRADES,
+      30_000,
+    );
+    expect(power).toBeGreaterThan(60_000);
   });
 });
+
+// ── computeComboMultiplier ────────────────────────────────────────────────────
 
 describe("computeComboMultiplier", () => {
   it("returns 1 when combo count is below threshold", () => {
@@ -262,6 +277,8 @@ describe("computeComboMultiplier", () => {
   });
 });
 
+// ── getNextComboCount ─────────────────────────────────────────────────────────
+
 describe("getNextComboCount", () => {
   it("returns 1 on first click (lastClickTime === 0)", () => {
     expect(getNextComboCount(0, 0, Date.now())).toBe(1);
@@ -298,6 +315,8 @@ describe("getNextComboCount", () => {
   });
 });
 
+// ── Constants ─────────────────────────────────────────────────────────────────
+
 describe("constants", () => {
   it("COMBO_CLICK_WINDOW_MS is 333 (≈3 clicks/sec)", () => {
     expect(COMBO_CLICK_WINDOW_MS).toBe(333);
@@ -314,7 +333,17 @@ describe("constants", () => {
   it("COMBO_MULTIPLIER is 1.5", () => {
     expect(COMBO_MULTIPLIER).toBe(1.5);
   });
+
+  it("BASE_CLICK_SECONDS is 0.05", () => {
+    expect(BASE_CLICK_SECONDS).toBe(0.05);
+  });
+
+  it("MASTERY_CLICK_SECONDS_PER_LEVEL is 0.1", () => {
+    expect(MASTERY_CLICK_SECONDS_PER_LEVEL).toBe(0.1);
+  });
 });
+
+// ── CLICK_UPGRADES data integrity ─────────────────────────────────────────────
 
 describe("CLICK_UPGRADES data integrity", () => {
   it("has 5 click upgrades", () => {
@@ -326,15 +355,24 @@ describe("CLICK_UPGRADES data integrity", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("all upgrades have multiplier > 1", () => {
+  it("all upgrades have clickSeconds > 0", () => {
     for (const u of CLICK_UPGRADES) {
-      expect(u.multiplier).toBeGreaterThan(1);
+      expect(u.clickSeconds).toBeGreaterThan(0);
     }
   });
 
-  it("total multiplier from all upgrades is 600x", () => {
-    const total = CLICK_UPGRADES.reduce((acc, u) => acc * u.multiplier, 1);
-    expect(total).toBe(600);
+  it("total clickSeconds from all upgrades is 2.0s", () => {
+    const total = CLICK_UPGRADES.reduce((acc, u) => acc + u.clickSeconds, 0);
+    expect(total).toBeCloseTo(2.0);
+  });
+
+  it("with all upgrades, each click gives ~2.05s of passive income", () => {
+    const allIds = CLICK_UPGRADES.map((u) => u.id);
+    const totalSeconds = computeClickSeconds(allIds, CLICK_UPGRADES);
+    expect(totalSeconds).toBeCloseTo(
+      BASE_CLICK_SECONDS + 0.1 + 0.15 + 0.25 + 0.5 + 1.0,
+    );
+    expect(totalSeconds).toBeGreaterThanOrEqual(2.0);
   });
 
   it("upgrades are ordered by cost", () => {

--- a/src/engine/clickEngine.ts
+++ b/src/engine/clickEngine.ts
@@ -12,35 +12,68 @@ export const COMBO_THRESHOLD = 3;
 /** Bonus multiplier applied when combo is active. */
 export const COMBO_MULTIPLIER = 1.5;
 
+/**
+ * Baseline seconds of passive income earned per click (before any upgrades).
+ * At 0 generators (tdPerSecond = 0) a floor of 1 TD applies.
+ */
+export const BASE_CLICK_SECONDS = 0.05;
+
+/**
+ * Seconds of passive income added per Click Mastery prestige level.
+ * 10 levels → +1.0s (same contribution as the Synthetic Data Farm upgrade).
+ */
+export const MASTERY_CLICK_SECONDS_PER_LEVEL = 0.1;
+
 interface ClickPowerState {
-  evolutionStage: number;
   clickUpgradesPurchased: string[];
   comboCount: number;
   lastClickTime: number;
 }
 
 /**
- * Compute the total click power.
+ * Returns the total click-seconds value for the given purchased upgrades and
+ * Click Mastery bonus level.
  *
- * Formula: (1 + evolutionStage + clickMasteryBonus)
- *          × product(purchased upgrade multipliers)
- *          × comboMultiplier × speciesClickMultiplier
+ * Formula: BASE_CLICK_SECONDS + Σ(purchased upgrade clickSeconds)
+ *          + clickMasteryBonus × MASTERY_CLICK_SECONDS_PER_LEVEL
+ */
+export function computeClickSeconds(
+  purchasedIds: string[],
+  clickUpgrades: readonly ClickUpgrade[],
+  clickMasteryBonus = 0,
+): number {
+  let seconds = BASE_CLICK_SECONDS;
+  for (const upgrade of clickUpgrades) {
+    if (purchasedIds.includes(upgrade.id)) {
+      seconds += upgrade.clickSeconds;
+    }
+  }
+  seconds += clickMasteryBonus * MASTERY_CLICK_SECONDS_PER_LEVEL;
+  return seconds;
+}
+
+/**
+ * Compute the total click value in TD.
+ *
+ * Formula: max(1, clickSeconds × tdPerSecond × comboMultiplier × speciesClickMultiplier)
+ *
+ * The floor of 1 preserves early-game playability before any generators are
+ * bought (when tdPerSecond = 0).  Once passive income is meaningful the
+ * formula fully governs the result.
  */
 export function computeClickPower(
   state: ClickPowerState,
   clickUpgrades: readonly ClickUpgrade[],
+  tdPerSecond: number,
   now?: number,
   clickMasteryBonus = 0,
   speciesClickMultiplier = 1,
 ): number {
-  const base = 1 + state.evolutionStage + clickMasteryBonus;
-
-  let upgradeMultiplier = 1;
-  for (const upgrade of clickUpgrades) {
-    if (state.clickUpgradesPurchased.includes(upgrade.id)) {
-      upgradeMultiplier *= upgrade.multiplier;
-    }
-  }
+  const seconds = computeClickSeconds(
+    state.clickUpgradesPurchased,
+    clickUpgrades,
+    clickMasteryBonus,
+  );
 
   const combo = computeComboMultiplier(
     state.comboCount,
@@ -48,7 +81,7 @@ export function computeClickPower(
     now,
   );
 
-  return base * upgradeMultiplier * combo * speciesClickMultiplier;
+  return Math.max(1, seconds * tdPerSecond * combo * speciesClickMultiplier);
 }
 
 /**

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -6,6 +6,7 @@ import {
   getClickMasteryBonus,
   getEvolutionThresholdMultiplier,
   getGeneratorCostMultiplier,
+  getIdleBoostMultiplier,
   getQuickStartTd,
   getRetainedTiers,
   getTokenMagnetMultiplier,
@@ -22,7 +23,12 @@ import {
   computeWisdomTokens,
   getNextSpecies,
 } from "../engine/rebirthEngine";
-import { getBulkCost, getUpgradeCost } from "../engine/upgradeEngine";
+import {
+  computeBoosterMultiplier,
+  getBulkCost,
+  getTotalTdPerSecond,
+  getUpgradeCost,
+} from "../engine/upgradeEngine";
 
 export interface GameState {
   trainingData: number;
@@ -149,14 +155,27 @@ export const useGameStore = create<GameStore>()(
             pLevel(state.prestigeUpgrades, "click-mastery"),
           );
           const speciesBonus = getSpeciesBonus(state.currentSpecies);
+          const idleBoost = getIdleBoostMultiplier(
+            pLevel(state.prestigeUpgrades, "idle-boost"),
+          );
+          const boosterMult = computeBoosterMultiplier(
+            BOOSTERS,
+            state.boostersPurchased,
+          );
+          const tdPerSecond = getTotalTdPerSecond(
+            UPGRADES,
+            state.upgradeOwned,
+            idleBoost * speciesBonus.autoGen,
+            boosterMult,
+          );
           const clickPower = computeClickPower(
             {
-              evolutionStage: state.evolutionStage,
               clickUpgradesPurchased: state.clickUpgradesPurchased,
               comboCount: newComboCount,
               lastClickTime: now,
             },
             CLICK_UPGRADES,
+            tdPerSecond,
             now,
             clickMastery,
             speciesBonus.clickPower,


### PR DESCRIPTION
## Summary

Fixes the mid/late-game irrelevance of click booster upgrades by tying click
power to the player's current passive income rate instead of a flat base value.

## Changes

- **`clickUpgrades.ts`** — Replaced `multiplier: number` with `clickSeconds: number`; each upgrade now adds seconds of passive income per click (0.10, 0.15, 0.25, 0.50, 1.00)
- **`clickEngine.ts`** — New formula: `max(1, clickSeconds × tdPerSecond × combo × species)`. Added `BASE_CLICK_SECONDS = 0.05` and `MASTERY_CLICK_SECONDS_PER_LEVEL = 0.1`. New exported `computeClickSeconds()` helper. Removed `evolutionStage` from `ClickPowerState`
- **`gameStore.ts`** — `clickFeed()` now computes `tdPerSecond` from live state (upgrade owned, boosters, species, idle-boost) and passes it to `computeClickPower`
- **`ClickUpgradeCard.tsx`** — Displays `+Xs per click` instead of `Nx click power`
- **`StatsBar.tsx`** — Added live "Click: X TD" display in the header bar
- **`PetDisplay.tsx`** — Updated `computeClickPower` call to new signature (tdPerSecond, no evolutionStage)
- **`clickEngine.test.ts`** — Full rewrite for the new formula; 44 tests covering `computeClickSeconds`, `computeClickPower` scaling, combo, species multiplier, mastery, mid/late-game examples, and CLICK_UPGRADES data integrity

## Story

[#73 — Click boosters become irrelevant in mid/late game](https://github.com/AshDevFr/GLORP/issues/73)

Fixes #73

## Testing

- `tsc -b` — passes
- `npx vitest run` — 524/524 tests pass
- `npx biome check --write .` — no issues
- Manual: early game (0 generators) clicks return 1 TD (floor); mid game with all upgrades at 1 000 TD/s → ~2 050 TD/click; late game at 30 000 TD/s → ~62 000 TD/click

— Devon (4shClaw developer agent)