### PR TITLE
feat: base64 clipboard save export/import (issue #64)

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -3,15 +3,20 @@ import {
   Divider,
   Drawer,
   FileButton,
+  Modal,
   Stack,
   Switch,
   Text,
+  Textarea,
 } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
 import { useState } from "react";
 import { useSettingsStore } from "../store/settingsStore";
 import {
   applySave,
   exportSave,
+  exportSaveToClipboard,
+  importSaveFromString,
   parseSaveFile,
   resetGame,
 } from "../utils/saveManager";
@@ -34,6 +39,54 @@ export function SettingsPanel({
 
   const [resetStage, setResetStage] = useState(0);
   const [importError, setImportError] = useState<string | null>(null);
+  const [importModalOpen, setImportModalOpen] = useState(false);
+  const [importText, setImportText] = useState("");
+  const [pasteError, setPasteError] = useState<string | null>(null);
+
+  async function handleCopyToClipboard() {
+    try {
+      await exportSaveToClipboard();
+      notifications.show({
+        title: "Save exported!",
+        message: "Save string copied to clipboard.",
+        color: "green",
+        autoClose: 4000,
+      });
+    } catch {
+      notifications.show({
+        title: "Export failed",
+        message: "Could not copy to clipboard.",
+        color: "red",
+        autoClose: 4000,
+      });
+    }
+  }
+
+  function handleOpenImportModal() {
+    setImportText("");
+    setPasteError(null);
+    setImportModalOpen(true);
+  }
+
+  function handleConfirmImport() {
+    setPasteError(null);
+    try {
+      const save = importSaveFromString(importText.trim());
+      applySave(save);
+      setImportModalOpen(false);
+      setImportText("");
+      notifications.show({
+        title: "Save imported!",
+        message: "Your game state has been restored.",
+        color: "green",
+        autoClose: 4000,
+      });
+    } catch (e) {
+      setPasteError(
+        e instanceof Error ? e.message : "Failed to import save string",
+      );
+    }
+  }
 
   async function handleImport(file: File | null) {
     if (!file) return;
@@ -63,86 +116,143 @@ export function SettingsPanel({
   }
 
   return (
-    <Drawer
-      opened={opened}
-      onClose={handleClose}
-      title={
-        <Text ff="monospace" fw={700}>
-          ⚙ Settings
-        </Text>
-      }
-      position="right"
-    >
-      <Stack gap="md">
-        <Switch
-          label="CRT Scanlines"
-          description="Apply a retro CRT scanline overlay"
-          checked={crtEnabled}
-          onChange={(e) => setCrtEnabled(e.currentTarget.checked)}
-          styles={{ label: { fontFamily: "monospace" } }}
-        />
-        <Switch
-          label="Disable Animations"
-          description="Turn off all animations and particle effects"
-          checked={animationsDisabled}
-          onChange={(e) => setAnimationsDisabled(e.currentTarget.checked)}
-          styles={{ label: { fontFamily: "monospace" } }}
-        />
-        <Switch
-          label="Full Number Display"
-          description="Show full numbers (1,234,567) instead of compact (1.23M)"
-          checked={numberFormat === "full"}
-          onChange={(e) =>
-            setNumberFormat(e.currentTarget.checked ? "full" : "compact")
-          }
-          styles={{ label: { fontFamily: "monospace" } }}
-        />
-
-        <Divider />
-
-        <Button
-          variant="default"
-          onClick={exportSave}
-          style={{ fontFamily: "monospace" }}
-        >
-          Export Save
-        </Button>
-
-        <FileButton accept="application/json" onChange={handleImport}>
-          {(props) => (
-            <Button
-              {...props}
-              variant="default"
-              style={{ fontFamily: "monospace" }}
-            >
-              Import Save
-            </Button>
+    <>
+      <Modal
+        opened={importModalOpen}
+        onClose={() => setImportModalOpen(false)}
+        title={
+          <Text ff="monospace" fw={700}>
+            Import Save
+          </Text>
+        }
+        centered
+      >
+        <Stack gap="sm">
+          <Text size="xs" ff="monospace" c="dimmed">
+            Paste your save string below and click Confirm to load it.
+          </Text>
+          <Textarea
+            placeholder="Paste save string here..."
+            value={importText}
+            onChange={(e) => setImportText(e.currentTarget.value)}
+            minRows={4}
+            styles={{ input: { fontFamily: "monospace", fontSize: 11 } }}
+            autoFocus
+          />
+          {pasteError && (
+            <Text c="red" size="xs" ff="monospace">
+              {pasteError}
+            </Text>
           )}
-        </FileButton>
+          <Button
+            onClick={handleConfirmImport}
+            disabled={importText.trim().length === 0}
+            style={{ fontFamily: "monospace" }}
+          >
+            Confirm Import
+          </Button>
+        </Stack>
+      </Modal>
 
-        {importError && (
-          <Text c="red" size="xs" ff="monospace">
-            {importError}
+      <Drawer
+        opened={opened}
+        onClose={handleClose}
+        title={
+          <Text ff="monospace" fw={700}>
+            ⚙ Settings
           </Text>
-        )}
+        }
+        position="right"
+      >
+        <Stack gap="md">
+          <Switch
+            label="CRT Scanlines"
+            description="Apply a retro CRT scanline overlay"
+            checked={crtEnabled}
+            onChange={(e) => setCrtEnabled(e.currentTarget.checked)}
+            styles={{ label: { fontFamily: "monospace" } }}
+          />
+          <Switch
+            label="Disable Animations"
+            description="Turn off all animations and particle effects"
+            checked={animationsDisabled}
+            onChange={(e) => setAnimationsDisabled(e.currentTarget.checked)}
+            styles={{ label: { fontFamily: "monospace" } }}
+          />
+          <Switch
+            label="Full Number Display"
+            description="Show full numbers (1,234,567) instead of compact (1.23M)"
+            checked={numberFormat === "full"}
+            onChange={(e) =>
+              setNumberFormat(e.currentTarget.checked ? "full" : "compact")
+            }
+            styles={{ label: { fontFamily: "monospace" } }}
+          />
 
-        <Divider />
+          <Divider />
 
-        <Button
-          color={resetStage === 1 ? "red" : "gray"}
-          variant={resetStage === 1 ? "filled" : "default"}
-          onClick={handleReset}
-          style={{ fontFamily: "monospace" }}
-        >
-          {resetStage === 1 ? "⚠ Confirm Reset" : "Reset Game"}
-        </Button>
+          <Button
+            variant="default"
+            onClick={exportSave}
+            style={{ fontFamily: "monospace" }}
+          >
+            Export Save (JSON file)
+          </Button>
 
-        {resetStage === 1 && (
-          <Text size="xs" c="dimmed" ff="monospace">
-            All progress will be lost. Click again to confirm.
-          </Text>
-        )}
-      </Stack>
-    </Drawer>
+          <FileButton accept="application/json" onChange={handleImport}>
+            {(props) => (
+              <Button
+                {...props}
+                variant="default"
+                style={{ fontFamily: "monospace" }}
+              >
+                Import Save (JSON file)
+              </Button>
+            )}
+          </FileButton>
+
+          {importError && (
+            <Text c="red" size="xs" ff="monospace">
+              {importError}
+            </Text>
+          )}
+
+          <Divider />
+
+          <Button
+            variant="default"
+            onClick={handleCopyToClipboard}
+            style={{ fontFamily: "monospace" }}
+          >
+            Copy Save to Clipboard
+          </Button>
+
+          <Button
+            variant="default"
+            onClick={handleOpenImportModal}
+            style={{ fontFamily: "monospace" }}
+          >
+            Import Save from Text
+          </Button>
+
+          <Divider />
+
+          <Button
+            color={resetStage === 1 ? "red" : "gray"}
+            variant={resetStage === 1 ? "filled" : "default"}
+            onClick={handleReset}
+            style={{ fontFamily: "monospace" }}
+          >
+            {resetStage === 1 ? "⚠ Confirm Reset" : "Reset Game"}
+          </Button>
+
+          {resetStage === 1 && (
+            <Text size="xs" c="dimmed" ff="monospace">
+              All progress will be lost. Click again to confirm.
+            </Text>
+          )}
+        </Stack>
+      </Drawer>
+    </>
   );
 }

--- a/src/utils/saveManager.test.ts
+++ b/src/utils/saveManager.test.ts
@@ -5,9 +5,12 @@ import { initialGameState, useGameStore } from "../store/gameStore";
 import {
   applySave,
   exportSave,
+  exportSaveToClipboard,
+  importSaveFromString,
   migrateSave,
   parseSaveFile,
   resetGame,
+  SAVE_ENVELOPE_VERSION,
   validateSave,
 } from "./saveManager";
 
@@ -221,5 +224,93 @@ describe("parseSaveFile", () => {
       type: "application/json",
     });
     await expect(parseSaveFile(file)).rejects.toThrow("Invalid save file");
+  });
+});
+
+describe("exportSaveToClipboard", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      writable: true,
+    });
+    useGameStore.setState({ ...initialGameState, trainingData: 42 });
+  });
+
+  it("copies a JSON string to clipboard", async () => {
+    await exportSaveToClipboard();
+    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+    const written = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0] as string;
+    expect(typeof written).toBe("string");
+  });
+
+  it("uses the version envelope", async () => {
+    await exportSaveToClipboard();
+    const written = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0] as string;
+    const envelope = JSON.parse(written) as { v: number; data: string };
+    expect(envelope.v).toBe(SAVE_ENVELOPE_VERSION);
+    expect(typeof envelope.data).toBe("string");
+  });
+
+  it("round-trips the game state", async () => {
+    await exportSaveToClipboard();
+    const written = (navigator.clipboard.writeText as ReturnType<typeof vi.fn>)
+      .mock.calls[0][0] as string;
+    const imported = importSaveFromString(written);
+    expect(imported.trainingData).toBe(42);
+  });
+});
+
+describe("importSaveFromString", () => {
+  function makeEnvelope(data: unknown): string {
+    return JSON.stringify({
+      v: SAVE_ENVELOPE_VERSION,
+      data: btoa(JSON.stringify(data)),
+    });
+  }
+
+  it("returns a valid GameState for a correct envelope", () => {
+    const result = importSaveFromString(makeEnvelope(validSave));
+    expect(result.trainingData).toBe(100);
+    expect(result.rebirthCount).toBe(1);
+  });
+
+  it("throws for non-JSON input", () => {
+    expect(() => importSaveFromString("not json")).toThrow("not valid JSON");
+  });
+
+  it("throws when envelope is missing the v field", () => {
+    expect(() =>
+      importSaveFromString(JSON.stringify({ data: btoa("{}") })),
+    ).toThrow("missing version envelope");
+  });
+
+  it("throws when envelope is missing the data field", () => {
+    expect(() => importSaveFromString(JSON.stringify({ v: 1 }))).toThrow(
+      "missing version envelope",
+    );
+  });
+
+  it("throws when data is not valid base64 JSON", () => {
+    expect(() =>
+      importSaveFromString(JSON.stringify({ v: 1, data: "!!!not-base64!!!" })),
+    ).toThrow("base64 decode failed");
+  });
+
+  it("throws when decoded object is missing required fields", () => {
+    expect(() => importSaveFromString(makeEnvelope({ foo: "bar" }))).toThrow(
+      "missing required game state fields",
+    );
+  });
+
+  it("does not modify game state on failure", () => {
+    useGameStore.setState({ trainingData: 9999 });
+    try {
+      importSaveFromString("garbage");
+    } catch {
+      // expected
+    }
+    expect(useGameStore.getState().trainingData).toBe(9999);
   });
 });

--- a/src/utils/saveManager.ts
+++ b/src/utils/saveManager.ts
@@ -105,3 +105,75 @@ export function applySave(save: GameState): void {
 export function resetGame(): void {
   useGameStore.setState({ ...initialGameState, lastSaved: Date.now() });
 }
+
+export const SAVE_ENVELOPE_VERSION = 1;
+
+export interface SaveEnvelope {
+  v: number;
+  data: string;
+}
+
+/**
+ * Encode the current game state as a versioned base64 string and copy it to
+ * the clipboard. Returns the encoded string.
+ */
+export async function exportSaveToClipboard(): Promise<string> {
+  const state = useGameStore.getState();
+  const exportKeys: (keyof GameState)[] = [
+    ...REQUIRED_KEYS,
+    "prestigeUpgrades",
+    "prestigeTokenBalance",
+    "hasOpenedPrestigeShop",
+    "boostersPurchased",
+    "easterEggsUnlocked",
+    "totalTimePlayed",
+    "crossedMilestones",
+  ];
+  const saveData: Partial<GameState> = {};
+  for (const key of exportKeys) {
+    (saveData as Record<string, unknown>)[key] = state[key];
+  }
+  const envelope: SaveEnvelope = {
+    v: SAVE_ENVELOPE_VERSION,
+    data: btoa(JSON.stringify(saveData)),
+  };
+  const encoded = JSON.stringify(envelope);
+  await navigator.clipboard.writeText(encoded);
+  return encoded;
+}
+
+/**
+ * Parse and validate a base64 save string (produced by exportSaveToClipboard).
+ * Throws a descriptive Error if the string is malformed or fails validation.
+ */
+export function importSaveFromString(str: string): GameState {
+  let envelope: unknown;
+  try {
+    envelope = JSON.parse(str);
+  } catch {
+    throw new Error("Invalid save string: not valid JSON");
+  }
+
+  if (
+    typeof envelope !== "object" ||
+    envelope === null ||
+    !("v" in envelope) ||
+    !("data" in envelope) ||
+    typeof (envelope as SaveEnvelope).data !== "string"
+  ) {
+    throw new Error("Invalid save string: missing version envelope");
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(atob((envelope as SaveEnvelope).data));
+  } catch {
+    throw new Error("Invalid save string: base64 decode failed");
+  }
+
+  if (!validateSave(decoded)) {
+    throw new Error("Invalid save string: missing required game state fields");
+  }
+
+  return migrateSave(decoded);
+}


### PR DESCRIPTION
## Summary

Adds base64 clipboard-based save export and import alongside the existing JSON file flow, enabling cross-device play and easy backups without touching the filesystem.

## Changes

- **`saveManager.ts`** — Two new exports:
  - `exportSaveToClipboard(): Promise<string>` — encodes game state as `{ v: 1, data: btoa(JSON.stringify(state)) }`, copies the envelope to clipboard, returns the encoded string
  - `importSaveFromString(str: string): GameState` — parses and validates the envelope, throws a descriptive error (without touching game state) if the string is malformed or fails schema validation
  - `SAVE_ENVELOPE_VERSION = 1` exported for tests and future migrations
  - `SaveEnvelope` interface exported

- **`SettingsPanel.tsx`** — Two new buttons in the data section:
  - **Copy Save to Clipboard** — calls `exportSaveToClipboard`, shows a green success toast or red error toast
  - **Import Save from Text** — opens a Mantine Modal with a textarea; validates on confirm, shows inline error on failure, shows success toast on apply

- **`saveManager.test.ts`** — 10 new tests:
  - `exportSaveToClipboard`: copies to clipboard, uses version envelope, round-trips state
  - `importSaveFromString`: happy path, non-JSON input, missing `v`, missing `data`, invalid base64, missing required fields, game state untouched on failure

## Story

[#64 — 9.4 Save export/import](https://github.com/AshDevFr/GLORP/issues/64)

Closes #64

## Testing

- `npx tsc -b` — passes
- `npx vitest run` — 561/561 tests pass (10 new)
- `npx biome check --write .` — no issues
- Manual: open Settings → "Copy Save to Clipboard" → green toast → paste in "Import Save from Text" modal → Confirm → game state restored identically

— Devon (4shClaw developer agent)