### PR TITLE
feat: dual-sidebar layout v2 — always-visible sidebars, 2-column upgrades grid

### DIFF
--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -1,11 +1,4 @@
-import {
-  AppShell,
-  Button,
-  Drawer,
-  Group,
-  SegmentedControl,
-} from "@mantine/core";
-import { useMediaQuery } from "@mantine/hooks";
+import { AppShell, Button, Group } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -42,15 +35,9 @@ export function GameLayout() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [statsOpen, setStatsOpen] = useState(false);
   const [konamiVisible, setKonamiVisible] = useState(false);
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [drawerTab, setDrawerTab] = useState("upgrades");
   const konamiTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const unlockedCount = useGameStore((s) => s.unlockedAchievements.length);
   const reducedMotion = useReducedMotion();
-
-  // Responsive breakpoints
-  const isDesktop = useMediaQuery("(min-width: 1280px)");
-  const isMedium = useMediaQuery("(min-width: 900px)");
 
   useEffect(() => {
     const state = useGameStore.getState();
@@ -99,36 +86,12 @@ export function GameLayout() {
 
   useKonamiCode(handleKonami);
 
-  // Close drawer when viewport grows past breakpoint
-  useEffect(() => {
-    if (isDesktop) setDrawerOpen(false);
-  }, [isDesktop]);
-
-  // Determine which sidebar(s) show as drawers
-  const showUpgradesSidebar = isMedium;
-  const showBonusesSidebar = isDesktop;
-  const needsDrawer = !isDesktop;
-
   return (
     <AppShell header={{ height: 44 }} padding={0}>
       <AppShell.Header>
         <Group h="100%" px="xs" justify="space-between" wrap="nowrap">
           <StatsBar />
           <Group gap="xs" wrap="nowrap">
-            {needsDrawer && (
-              <Button
-                size="xs"
-                variant="subtle"
-                color="green"
-                onClick={() => setDrawerOpen(true)}
-                style={{ fontFamily: "monospace" }}
-                aria-label={
-                  isMedium ? "Open bonuses panel" : "Open upgrades and bonuses"
-                }
-              >
-                {isMedium ? "⚡ Bonuses" : "📋 Panels"}
-              </Button>
-            )}
             <Button
               size="xs"
               variant="subtle"
@@ -163,54 +126,13 @@ export function GameLayout() {
 
       <AppShell.Main>
         <div className="game-layout">
-          {showUpgradesSidebar && <UpgradesSidebar />}
+          <UpgradesSidebar />
           <div className="game-center">
             <PetDisplay />
           </div>
-          {showBonusesSidebar && <BonusesSidebar />}
+          <BonusesSidebar />
         </div>
       </AppShell.Main>
-
-      {/* Bottom drawer for responsive layouts */}
-      <Drawer
-        opened={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
-        position="bottom"
-        size="70vh"
-        title={null}
-        styles={{
-          body: {
-            padding: 0,
-            height: "100%",
-            display: "flex",
-            flexDirection: "column",
-          },
-          content: { display: "flex", flexDirection: "column" },
-        }}
-      >
-        {!isMedium && (
-          <SegmentedControl
-            value={drawerTab}
-            onChange={setDrawerTab}
-            fullWidth
-            data={[
-              { label: "🔧 Upgrades", value: "upgrades" },
-              { label: "⚡ Bonuses", value: "bonuses" },
-            ]}
-            style={{ margin: "0 var(--mantine-spacing-sm)" }}
-            styles={{ root: { fontFamily: "monospace" } }}
-          />
-        )}
-        <div style={{ flex: 1, overflow: "hidden" }}>
-          {isMedium ? (
-            <BonusesSidebar />
-          ) : drawerTab === "upgrades" ? (
-            <UpgradesSidebar />
-          ) : (
-            <BonusesSidebar />
-          )}
-        </div>
-      </Drawer>
 
       <OfflineProgressModal
         result={offlineResult}

--- a/src/components/UpgradesSidebar.tsx
+++ b/src/components/UpgradesSidebar.tsx
@@ -196,7 +196,7 @@ export function UpgradesSidebar() {
                     in={openCategories["click-boosters"] ?? true}
                     transitionDuration={200}
                   >
-                    <Stack gap="xs" mt={4}>
+                    <div className="upgrades-grid" style={{ marginTop: 4 }}>
                       {visibleClickUpgrades.map((upgrade) => {
                         const purchased = clickUpgradesPurchased.includes(
                           upgrade.id,
@@ -218,7 +218,7 @@ export function UpgradesSidebar() {
                           </div>
                         );
                       })}
-                    </Stack>
+                    </div>
                   </Collapse>
                 </div>
               )}
@@ -237,7 +237,7 @@ export function UpgradesSidebar() {
                       in={openCategories[tc.tier] ?? true}
                       transitionDuration={200}
                     >
-                      <Stack gap="xs" mt={4}>
+                      <div className="upgrades-grid" style={{ marginTop: 4 }}>
                         {tierUpgrades.map((upgrade) => (
                           <UpgradeCard
                             key={upgrade.id}
@@ -250,7 +250,7 @@ export function UpgradesSidebar() {
                             costMultiplier={costMultiplier}
                           />
                         ))}
-                      </Stack>
+                      </div>
                     </Collapse>
                   </div>
                 );

--- a/src/components/upgrades/UpgradeCard.tsx
+++ b/src/components/upgrades/UpgradeCard.tsx
@@ -123,6 +123,7 @@ export function UpgradeCard({
       padding="sm"
       radius="sm"
       withBorder
+      aria-disabled={!canAfford ? "true" : undefined}
       style={{
         borderColor: isMilestoneGlowing
           ? "var(--mantine-color-yellow-6)"

--- a/src/global.css
+++ b/src/global.css
@@ -215,12 +215,13 @@ body {
 .game-layout {
   display: flex;
   height: calc(100dvh - 44px);
+  min-width: 860px;
   overflow: hidden;
 }
 
 .game-center {
   flex: 1;
-  min-width: 0;
+  min-width: 300px;
   height: 100%;
   overflow: hidden;
 }
@@ -230,25 +231,34 @@ body {
 .sidebar-upgrades,
 .sidebar-bonuses {
   height: 100%;
-  overflow: hidden;
+  overflow-y: auto;
   flex-shrink: 0;
 }
 
 .sidebar-upgrades {
-  width: 280px;
+  width: 320px;
   border-right: 1px solid var(--mantine-color-dark-4);
 }
 
 .sidebar-bonuses {
-  width: 300px;
+  width: 240px;
   border-left: 1px solid var(--mantine-color-dark-4);
 }
 
-/* ── Bonuses grid: 2-column card layout ────────────────────────────────── */
+/* ── Upgrades grid: 2-column card layout inside each tier ──────────────── */
+
+.upgrades-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+/* ── Bonuses grid: single-column generator list ────────────────────────── */
 
 .bonuses-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  grid-template-columns: 1fr;
   gap: var(--mantine-spacing-xs);
 }
 


### PR DESCRIPTION
## Summary
Revised dual-sidebar layout (v2) superseding #83. Both sidebars are now always visible — no responsive breakpoints, no drawer, no toggle buttons.

## Changes
- **`global.css`**: `.game-layout` gets `min-width: 860px`; `.sidebar-upgrades` → 320px wide; `.sidebar-bonuses` → 240px wide; both get `overflow-y: auto`. New `.upgrades-grid` class (2-column `1fr 1fr` grid). `.bonuses-grid` simplified to single-column `1fr`.
- **`GameLayout.tsx`**: Removed `useMediaQuery`, `isDesktop`/`isMedium` variables, `drawerOpen`/`drawerTab` state, the viewport-change `useEffect`, the "Panels" drawer button, and the entire `<Drawer>` component. Both `<UpgradesSidebar />` and `<BonusesSidebar />` now always render.
- **`UpgradesSidebar.tsx`**: Replaced `<Stack gap="xs">` inside each tier's `<Collapse>` with `<div className="upgrades-grid">` — upgrade cards now display 2 per row.
- **`UpgradeCard.tsx`**: Added `aria-disabled={!canAfford ? "true" : undefined}` to the `<Card>` element for accessibility.

## Story
[[UX] Dual-sidebar layout v2](https://github.com/AshDevFr/GLORP/issues/84)

Closes #84

## Testing
- `tsc -b` passes clean
- `npx vitest run` — 577 tests pass
- `npx biome check --write .` — no issues
- Visual: both sidebars always visible at any viewport ≥ 860px; upgrade cards render in 2-column grid within each tier accordion

— Devon (4shClaw developer agent)