### PR TITLE
fix: rebirth always resets upgradeOwned to {} — stops TD/s carry-over

### DIFF
--- a/src/store/gameStore.test.ts
+++ b/src/store/gameStore.test.ts
@@ -445,7 +445,7 @@ describe("gameStore", () => {
       expect(state.activeChallengeId).toBe("no-prestige");
     });
 
-    it("no-prestige challenge disables species-memory for next run", () => {
+    it("resets upgradeOwned to {} regardless of species-memory prestige", () => {
       useGameStore.setState({
         totalTdEarned: 2_000_000,
         evolutionStage: 5,
@@ -455,6 +455,77 @@ describe("gameStore", () => {
       useGameStore.getState().performRebirth(undefined, "no-prestige");
       const state = useGameStore.getState();
       expect(state.upgradeOwned).toEqual({});
+    });
+  });
+
+  describe("rebirth reset", () => {
+    it("resets upgradeOwned to {} after rebirth", () => {
+      useGameStore.setState({
+        totalTdEarned: 2_000_000,
+        evolutionStage: 5,
+        upgradeOwned: { "neural-notepad": 50, "quantum-processor": 100 },
+      });
+      useGameStore.getState().performRebirth();
+      expect(useGameStore.getState().upgradeOwned).toEqual({});
+    });
+
+    it("resets upgradeOwned to {} even with species-memory prestige active", () => {
+      useGameStore.setState({
+        totalTdEarned: 2_000_000,
+        evolutionStage: 5,
+        prestigeUpgrades: { "species-memory": 5 },
+        upgradeOwned: {
+          "neural-notepad": 100,
+          "mind-singularity": 50,
+          "infinite-regression": 30,
+        },
+      });
+      useGameStore.getState().performRebirth();
+      expect(useGameStore.getState().upgradeOwned).toEqual({});
+    });
+
+    it("resets evolutionStage to 0 after rebirth with no quick-start", () => {
+      useGameStore.setState({
+        totalTdEarned: 10_000_000,
+        evolutionStage: 4,
+      });
+      useGameStore.getState().performRebirth();
+      expect(useGameStore.getState().evolutionStage).toBe(0);
+    });
+
+    it("resets totalTdEarned to 0 after rebirth with no quick-start", () => {
+      useGameStore.setState({
+        totalTdEarned: 5_000_000,
+        evolutionStage: 4,
+      });
+      useGameStore.getState().performRebirth();
+      expect(useGameStore.getState().totalTdEarned).toBe(0);
+    });
+
+    it("preserves prestigeUpgrades (Wisdom bonuses) after rebirth", () => {
+      useGameStore.setState({
+        totalTdEarned: 2_000_000,
+        evolutionStage: 5,
+        prestigeUpgrades: { "idle-boost": 3, "click-mastery": 5 },
+      });
+      useGameStore.getState().performRebirth();
+      expect(useGameStore.getState().prestigeUpgrades).toEqual({
+        "idle-boost": 3,
+        "click-mastery": 5,
+      });
+    });
+
+    it("sets evolutionStage based on quickStartTd when quick-start prestige active", () => {
+      // quick-start level 2 = 10_000 TD; getEvolutionStage(10_000) = stage 2 (unlockAt 5_000)
+      useGameStore.setState({
+        totalTdEarned: 2_000_000,
+        evolutionStage: 5,
+        prestigeUpgrades: { "quick-start": 2 },
+      });
+      useGameStore.getState().performRebirth();
+      const state = useGameStore.getState();
+      expect(state.totalTdEarned).toBe(10_000);
+      expect(state.evolutionStage).toBe(2);
     });
   });
 });

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -9,7 +9,6 @@ import {
   getGeneratorCostMultiplier,
   getIdleBoostMultiplier,
   getQuickStartTd,
-  getRetainedTiers,
   getTokenMagnetMultiplier,
   PRESTIGE_UPGRADES,
 } from "../data/prestigeShop";
@@ -420,26 +419,8 @@ export const useGameStore = create<GameStore>()(
               : [...state.unlockedSpecies, nextSpecies];
           }
 
-          // No-prestige challenge for next run: disable quick-start and species-memory
+          // No-prestige challenge for next run: disable quick-start
           const nextRunNoPrest = challengeId === "no-prestige";
-
-          // Species Memory: retain owned generators in retained tiers
-          const retainedTiers = nextRunNoPrest
-            ? []
-            : getRetainedTiers(
-                pLevel(state.prestigeUpgrades, "species-memory"),
-              );
-          const retainedUpgrades: Record<string, number> = {};
-          if (retainedTiers.length > 0) {
-            for (const u of UPGRADES) {
-              if (retainedTiers.includes(u.tier)) {
-                const count = state.upgradeOwned[u.id];
-                if (count && count > 0) {
-                  retainedUpgrades[u.id] = count;
-                }
-              }
-            }
-          }
 
           // Quick Start TD
           const quickStartTd = nextRunNoPrest
@@ -457,7 +438,7 @@ export const useGameStore = create<GameStore>()(
             totalTdEarned: quickStartTd,
             evolutionStage:
               quickStartTd > 0 ? getEvolutionStage(quickStartTd) : 0,
-            upgradeOwned: retainedUpgrades,
+            upgradeOwned: {},
             mood: "Neutral" as Mood,
             moodChangedAt: now,
             hasSeenFirstEvolution: false,


### PR DESCRIPTION
## Summary
Fixes rebirth not resetting TD/s. `Species Memory` was retaining generator counts (`upgradeOwned`) across rebirths, causing TD/s to remain non-zero at the start of a new run. With late-game generators (e.g. `infinite-regression` at 35M TD/s base), the first game tick added billions of TD, instantly jumping `evolutionStage` to maximum — making the creature appear to skip directly to the previous run's final level.

## Root Cause
`performRebirth` populated `retainedUpgrades` from `getRetainedTiers` (Species Memory prestige) and assigned it to `upgradeOwned`. This meant all TD/s from retained generators carried over into the new run, and the first tick caused an immediate stage jump.

## Changes
- **`src/store/gameStore.ts`**: Removed `getRetainedTiers` import and the Species Memory generator-retention block from `performRebirth`. `upgradeOwned` is now always reset to `{}` on rebirth, regardless of any prestige upgrade. Wisdom/prestige bonuses (`prestigeUpgrades`, `prestigeTokenBalance`) are correctly preserved.
- **`src/store/gameStore.test.ts`**: Added new `describe("rebirth reset")` block with 6 tests covering: `upgradeOwned` always resets to `{}`, resets even with `species-memory` prestige at level 5, `evolutionStage` resets to 0, `totalTdEarned` resets to 0, `prestigeUpgrades` persist (Wisdom bonuses preserved), and `evolutionStage` is computed from `quickStartTd` when Quick Start prestige is active.

## Story
[bug: Rebirth does not reset TD/s — creature jumps to max level instantly](https://github.com/AshDevFr/GLORP/issues/87)

Closes #87

## Testing
- `tsc -b` passes clean
- `npx vitest run` — 583 tests pass (577 baseline + 6 new)
- `npx biome check --write .` — no issues
- Manual: rebirth from stage 5 with large `upgradeOwned` → creature starts at stage 0 with TD/s = 0

— Devon (4shClaw developer agent)