### PR TITLE
fix: rebalance Wisdom Token economy (divisor 500K → 5M)

### DIFF
--- a/src/engine/rebirthEngine.test.ts
+++ b/src/engine/rebirthEngine.test.ts
@@ -32,18 +32,34 @@ describe("computeWisdomTokens", () => {
   });
 
   it("floors fractional results", () => {
-    // floor(sqrt(1_000_000 / 500_000)) = floor(sqrt(2)) = floor(1.414) = 1
-    expect(computeWisdomTokens(1_000_000)).toBe(1);
+    // floor(sqrt(2 * 5_000_000 / 5_000_000)) = floor(sqrt(2)) = floor(1.414) = 1
+    expect(computeWisdomTokens(2 * WISDOM_TOKENS_DIVISOR)).toBe(1);
   });
 
-  it("returns ~4 tokens at minimum rebirth TD (stage 4 = 10M)", () => {
-    // floor(sqrt(10_000_000 / 500_000)) = floor(sqrt(20)) = floor(4.47) = 4
-    expect(computeWisdomTokens(10_000_000)).toBe(4);
+  it("returns 1 token at minimum rebirth TD (stage 4 = 10M)", () => {
+    // floor(sqrt(10_000_000 / 5_000_000)) = floor(sqrt(2)) = floor(1.414) = 1
+    expect(computeWisdomTokens(10_000_000)).toBe(1);
   });
 
   it("scales correctly at 50M TD (mid-game rebirth)", () => {
-    // floor(sqrt(50_000_000 / 500_000)) = floor(sqrt(100)) = 10
-    expect(computeWisdomTokens(50_000_000)).toBe(10);
+    // floor(sqrt(50_000_000 / 5_000_000)) = floor(sqrt(10)) = floor(3.162) = 3
+    expect(computeWisdomTokens(50_000_000)).toBe(3);
+  });
+
+  // Balance snapshots (divisor = 5_000_000)
+  it("balance: returns 14 tokens at 1B TD (stage 5 min)", () => {
+    // floor(sqrt(1_000_000_000 / 5_000_000)) = floor(sqrt(200)) = floor(14.14) = 14
+    expect(computeWisdomTokens(1_000_000_000)).toBe(14);
+  });
+
+  it("balance: returns 35 tokens at 1B TD with max multiplier (2.5x)", () => {
+    // base = 14, floor(14 * 2.5) = 35
+    expect(computeWisdomTokens(1_000_000_000, 2.5)).toBe(35);
+  });
+
+  it("balance: returns 31 tokens at 5B TD (extended stage 5 play)", () => {
+    // floor(sqrt(5_000_000_000 / 5_000_000)) = floor(sqrt(1000)) = floor(31.62) = 31
+    expect(computeWisdomTokens(5_000_000_000)).toBe(31);
   });
 
   it("applies tokenMagnetMultiplier", () => {

--- a/src/engine/rebirthEngine.ts
+++ b/src/engine/rebirthEngine.ts
@@ -5,7 +5,7 @@ import { SPECIES_ORDER } from "../data/species";
 export const REBIRTH_MIN_STAGE = 4;
 
 /** Divisor used in the Wisdom Token formula: floor(sqrt(totalTdEarned / divisor)). */
-export const WISDOM_TOKENS_DIVISOR = 500_000;
+export const WISDOM_TOKENS_DIVISOR = 5_000_000;
 
 /**
  * Number of Wisdom Tokens earned for a Rebirth given the total TD earned

--- a/src/store/gameStore.test.ts
+++ b/src/store/gameStore.test.ts
@@ -337,7 +337,7 @@ describe("gameStore", () => {
 
     it("performRebirth awards tokens and increments balance", () => {
       useGameStore.setState({
-        totalTdEarned: 2_000_000, // floor(sqrt(2_000_000 / 500_000)) = floor(sqrt(4)) = 2 tokens
+        totalTdEarned: 20_000_000, // floor(sqrt(20_000_000 / 5_000_000)) = floor(sqrt(4)) = 2 tokens
         evolutionStage: 5,
         prestigeTokenBalance: 0,
         wisdomTokens: 0,
@@ -408,7 +408,7 @@ describe("gameStore", () => {
     it("awards 2x tokens when challenge is completed", () => {
       // click-only challenge, need stage >= 3
       useGameStore.setState({
-        totalTdEarned: 2_000_000, // base = floor(sqrt(4)) = 2
+        totalTdEarned: 20_000_000, // base = floor(sqrt(20_000_000 / 5_000_000)) = floor(sqrt(4)) = 2
         evolutionStage: 5,
         activeChallengeId: "click-only",
         runStart: Date.now() - 1000,
@@ -422,7 +422,7 @@ describe("gameStore", () => {
     it("does not award bonus when challenge is not completed", () => {
       // no-prestige needs stage 5, give stage 4 only
       useGameStore.setState({
-        totalTdEarned: 2_000_000,
+        totalTdEarned: 20_000_000, // floor(sqrt(20_000_000 / 5_000_000)) = floor(sqrt(4)) = 2
         evolutionStage: 4,
         activeChallengeId: "no-prestige",
         runStart: Date.now() - 1000,


### PR DESCRIPTION
## Summary

Increases `WISDOM_TOKENS_DIVISOR` from `500_000` to `5_000_000` so players need 5–10+ meaningful runs to unlock the full prestige shop, rather than 1–2 runs.

## Changes

- `src/engine/rebirthEngine.ts`: `WISDOM_TOKENS_DIVISOR` 500_000 → 5_000_000
- `src/engine/rebirthEngine.test.ts`: Updated 3 absolute-value tests; added 3 balance-snapshot tests
- `src/store/gameStore.test.ts`: Updated 3 tests that used `2_000_000` TD (now yields 0 tokens under new divisor) to use `20_000_000` TD (still yields 2 tokens)

## Balance snapshots (new divisor = 5_000_000)

| TD earned | Tokens (no multiplier) | Tokens (max 2.5×) |
|-----------|----------------------|-------------------|
| 10M (min rebirth, stage 4) | 1 | 2 |
| 50M (mid-game) | 3 | 7 |
| 1B (stage 5 threshold) | 14 | 35 |
| 5B (extended play) | 31 | 77 |

Total prestige shop cost: 364 tokens — requires sustained play across multiple runs.

## Story

Fixes #86 — Rebirth grants too much Wisdom — game nearly complete after 1–2 runs

## Testing

- 586 tests pass (`npx vitest run`)
- `npx tsc -b` clean
- `npx biome check` clean

— Devon (4shClaw developer agent)