### PR TITLE
chore: remove dead getRetainedTiers from prestigeShop.ts

### DIFF
--- a/src/data/prestigeShop.test.ts
+++ b/src/data/prestigeShop.test.ts
@@ -7,7 +7,6 @@ import {
   getPrestigeCost,
   getPrestigeOfflineEfficiency,
   getQuickStartTd,
-  getRetainedTiers,
   getTokenMagnetMultiplier,
   PRESTIGE_UPGRADES,
 } from "./prestigeShop";
@@ -132,29 +131,5 @@ describe("getTokenMagnetMultiplier", () => {
 
   it("returns 2 at level 5", () => {
     expect(getTokenMagnetMultiplier(5)).toBeCloseTo(2);
-  });
-});
-
-describe("getRetainedTiers", () => {
-  it("returns empty at level 0", () => {
-    expect(getRetainedTiers(0)).toEqual([]);
-  });
-
-  it("returns first tier at level 1", () => {
-    expect(getRetainedTiers(1)).toEqual(["garage-lab"]);
-  });
-
-  it("returns first 3 tiers at level 3", () => {
-    expect(getRetainedTiers(3)).toEqual(["garage-lab", "startup", "scale-up"]);
-  });
-
-  it("returns all 5 tiers at level 5", () => {
-    expect(getRetainedTiers(5)).toEqual([
-      "garage-lab",
-      "startup",
-      "scale-up",
-      "mega-corp",
-      "transcendence",
-    ]);
   });
 });

--- a/src/data/prestigeShop.ts
+++ b/src/data/prestigeShop.ts
@@ -90,15 +90,6 @@ export const PRESTIGE_UPGRADES: readonly PrestigeUpgrade[] = [
   },
 ];
 
-/** Generator tiers in order, matching Upgrade.tier values. */
-const TIER_ORDER: readonly string[] = [
-  "garage-lab",
-  "startup",
-  "scale-up",
-  "mega-corp",
-  "transcendence",
-];
-
 /** Returns the cost for the next level of a prestige upgrade. */
 export function getPrestigeCost(upgrade: PrestigeUpgrade): number {
   return upgrade.costPerLevel;
@@ -138,9 +129,4 @@ export function getClickMasteryBonus(level: number): number {
 /** Token Magnet multiplier applied to WT earned on rebirth. */
 export function getTokenMagnetMultiplier(level: number): number {
   return 1 + level * 0.2;
-}
-
-/** Returns tiers retained across rebirth by Species Memory level. */
-export function getRetainedTiers(level: number): readonly string[] {
-  return TIER_ORDER.slice(0, level);
 }


### PR DESCRIPTION
## Summary

Removes the dead `getRetainedTiers` function and its supporting `TIER_ORDER` constant from `src/data/prestigeShop.ts`. These were left over from the Species Memory prestige rework and are no longer called anywhere in the codebase.

Also removes the corresponding import and test block from `src/data/prestigeShop.test.ts`.

## Changes

- **`src/data/prestigeShop.ts`**: Deleted `TIER_ORDER` constant and `getRetainedTiers` function
- **`src/data/prestigeShop.test.ts`**: Removed `getRetainedTiers` import and its `describe` test block

## Verification

- Project-wide search confirms zero remaining references to `getRetainedTiers` or `TIER_ORDER`
- `gameStore.ts` does not import `getRetainedTiers` — confirmed no call sites
- `rebirthEngine.ts` does not reference it either
- All other exports from `prestigeShop.ts` are untouched

Closes #90

-- Devon (HiveLabs developer agent)