### PR TITLE
fix: apply combo multiplier to TD gained per click (#93)

### DIFF
--- a/src/engine/clickEngine.test.ts
+++ b/src/engine/clickEngine.test.ts
@@ -156,6 +156,26 @@ describe("computeClickPower", () => {
     expect(power).toBeCloseTo(expectedBase * COMBO_MULTIPLIER);
   });
 
+  it("applies combo multiplier to the base-1 floor when tdPerSecond is 0", () => {
+    const now = Date.now();
+    // comboCount COMBO_THRESHOLD * 4 = 12 → multiplier is exactly 2.0:
+    //   1 + (COMBO_MULTIPLIER - 1) * sqrt(12 / COMBO_THRESHOLD)
+    //   = 1 + 0.5 * sqrt(4) = 1 + 0.5 * 2 = 2.0
+    // floor(max(1, 0) * 2.0) = floor(2.0) = 2
+    const power = computeClickPower(
+      {
+        clickUpgradesPurchased: [],
+        comboCount: COMBO_THRESHOLD * 4,
+        lastClickTime: now,
+      },
+      mockUpgrades,
+      0,
+      now,
+    );
+    expect(power).toBe(2);
+  });
+
+
   it("applies species click multiplier", () => {
     const tdPerSecond = 1000;
     const power = computeClickPower(

--- a/src/engine/clickEngine.ts
+++ b/src/engine/clickEngine.ts
@@ -55,11 +55,11 @@ export function computeClickSeconds(
 /**
  * Compute the total click value in TD.
  *
- * Formula: max(1, clickSeconds × tdPerSecond × comboMultiplier × speciesClickMultiplier)
+ * Formula: floor(max(1, clickSeconds × tdPerSecond × speciesClickMultiplier) × comboMultiplier)
  *
  * The floor of 1 preserves early-game playability before any generators are
- * bought (when tdPerSecond = 0).  Once passive income is meaningful the
- * formula fully governs the result.
+ * bought (when tdPerSecond = 0).  The combo multiplier is applied after the
+ * floor so it remains effective even when tdPerSecond = 0.
  */
 export function computeClickPower(
   state: ClickPowerState,
@@ -81,7 +81,9 @@ export function computeClickPower(
     now,
   );
 
-  return Math.max(1, seconds * tdPerSecond * combo * speciesClickMultiplier);
+  return Math.floor(
+    Math.max(1, seconds * tdPerSecond * speciesClickMultiplier) * combo,
+  );
 }
 
 /**

--- a/src/store/gameStore.test.ts
+++ b/src/store/gameStore.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { UPGRADES } from "../data/upgrades";
+import { COMBO_THRESHOLD, COMBO_MULTIPLIER } from "../engine/clickEngine";
 import { getUpgradeCost } from "../engine/upgradeEngine";
 import { initialGameState, useGameStore } from "./gameStore";
 
@@ -69,6 +70,27 @@ describe("gameStore", () => {
       expect(state.trainingData).toBe(3);
       expect(state.totalClicks).toBe(3);
       expect(state.totalTdEarned).toBe(3);
+    });
+
+    it("awards floor(1 × comboMultiplier) TD per click when combo is active", () => {
+      // Set comboCount to 11 so the next click brings it to 12 (= COMBO_THRESHOLD * 4).
+      // At comboCount 12 the multiplier is exactly 2.0:
+      //   1 + (COMBO_MULTIPLIER - 1) * sqrt(12 / COMBO_THRESHOLD)
+      //   = 1 + (1.5 - 1) * sqrt(4) = 1 + 0.5 * 2 = 2.0
+      // With no generators (tdPerSecond = 0) the base is 1 TD, so the click
+      // should award floor(1 * 2.0) = 2 TD.
+      const now = 5000;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
+      useGameStore.setState({
+        ...initialGameState,
+        comboCount: COMBO_THRESHOLD * 4 - 1, // 11
+        lastClickTime: now - 100, // 100 ms ago — within COMBO_DECAY_MS
+      });
+
+      useGameStore.getState().clickFeed();
+
+      expect(useGameStore.getState().trainingData).toBe(2);
+      expect(useGameStore.getState().totalTdEarned).toBe(2);
     });
   });
 


### PR DESCRIPTION
## Summary

- Combo multiplier was cosmetic: when `tdPerSecond = 0` (no generators), the multiplier was multiplied against 0 inside `Math.max(1, …)`, so the floor of 1 always applied regardless of combo level.
- Fix moves the combo factor outside the guard so it scales the floored base:
  ```
  // Before
  Math.max(1, seconds × tdPerSecond × combo × speciesMultiplier)

  // After
  Math.floor(Math.max(1, seconds × tdPerSecond × speciesMultiplier) × combo)
  ```
- At `1.00×` (no combo) the result is unchanged: `floor(1 × 1) = 1`.
- At a `2.00×` combo with no generators: `floor(1 × 2.0) = 2 TD` per click ✓

## Changes

- **`src/engine/clickEngine.ts`** — updated `computeClickPower` formula and JSDoc.
- **`src/engine/clickEngine.test.ts`** — new test: `"applies combo multiplier to the base-1 floor when tdPerSecond is 0"`.
- **`src/store/gameStore.test.ts`** — new test: `"awards floor(1 × comboMultiplier) TD per click when combo is active"`.

## Story

Closes #93

## Testing Instructions

1. `npm test` — all existing tests pass; two new tests cover the fixed behaviour.
2. In-game: build a combo streak (click rapidly), observe that TD counter increments by more than 1 per click when the badge shows a multiplier > 1×.
3. At 1× (fresh session or after combo decays) each click still grants exactly +1 TD.

-- Devon (HiveLabs developer agent)