### PR TITLE
fix: resolve Biome lint errors breaking CI on main (post #110)

### DIFF
--- a/src/components/upgrades/ClickUpgradeCard.tsx
+++ b/src/components/upgrades/ClickUpgradeCard.tsx
@@ -1,8 +1,17 @@
-import { Badge, Button, Card, Group, Text } from "@mantine/core";
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Card,
+  Group,
+  Popover,
+  Text,
+} from "@mantine/core";
 import { useCallback, useRef, useState } from "react";
 import type { ClickUpgrade } from "../../data/clickUpgrades";
 import { useReducedMotion } from "../../hooks/useReducedMotion";
 import { formatNumber } from "../../utils/formatNumber";
+import { ClickUpgradeTooltipContent } from "./ClickUpgradeTooltipContent";
 
 interface ClickUpgradeCardProps {
   upgrade: ClickUpgrade;
@@ -22,6 +31,8 @@ export function ClickUpgradeCard({
   const canAfford = !purchased && trainingData >= upgrade.cost;
   const locked = evolutionStage < upgrade.unlockStage;
   const [isGlowing, setIsGlowing] = useState(false);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const isHoverDevice = useRef(false);
   const glowTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const prefersReduced = useReducedMotion();
 
@@ -37,53 +48,88 @@ export function ClickUpgradeCard({
   if (locked) return null;
 
   return (
-    <Card
-      className={isGlowing ? "glow-pulse" : undefined}
-      padding="sm"
-      radius="sm"
-      withBorder
-      style={{
-        borderColor: purchased
-          ? "var(--mantine-color-yellow-8)"
-          : canAfford
-            ? "var(--mantine-color-green-8)"
-            : "var(--mantine-color-dark-4)",
-        opacity: purchased ? 0.7 : canAfford ? 1 : 0.5,
-        animation: isGlowing ? "glow-pulse 0.6s ease-in-out" : undefined,
-      }}
+    <Popover
+      opened={tooltipOpen}
+      onChange={setTooltipOpen}
+      position="right"
+      withArrow
+      shadow="md"
+      withinPortal
     >
-      <Group justify="space-between" mb={4}>
-        <Text size="sm" fw={700} ff="monospace">
-          {upgrade.icon} {upgrade.name}
-        </Text>
-        {purchased && (
-          <Badge size="sm" variant="light" color="yellow">
-            OWNED
-          </Badge>
-        )}
-      </Group>
+      <Popover.Target>
+        <Card
+          onMouseEnter={() => {
+            isHoverDevice.current = true;
+            setTooltipOpen(true);
+          }}
+          onMouseLeave={() => setTooltipOpen(false)}
+          className={isGlowing ? "glow-pulse" : undefined}
+          padding="sm"
+          radius="sm"
+          withBorder
+          style={{
+            borderColor: purchased
+              ? "var(--mantine-color-yellow-8)"
+              : canAfford
+                ? "var(--mantine-color-green-8)"
+                : "var(--mantine-color-dark-4)",
+            opacity: purchased ? 0.7 : canAfford ? 1 : 0.5,
+            animation: isGlowing ? "glow-pulse 0.6s ease-in-out" : undefined,
+          }}
+        >
+          <Group justify="space-between" mb={4} wrap="nowrap">
+            <Text size="sm" fw={700} ff="monospace">
+              {upgrade.icon} {upgrade.name}
+            </Text>
+            <Group gap={4} wrap="nowrap">
+              {purchased && (
+                <Badge size="sm" variant="light" color="yellow">
+                  OWNED
+                </Badge>
+              )}
+              <ActionIcon
+                size="xs"
+                variant="subtle"
+                color="gray"
+                aria-label={`Show details for ${upgrade.name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!isHoverDevice.current) {
+                    setTooltipOpen((o) => !o);
+                  }
+                }}
+              >
+                ℹ
+              </ActionIcon>
+            </Group>
+          </Group>
 
-      <Text size="xs" c="dimmed" ff="monospace" mb="xs">
-        {upgrade.description}
-      </Text>
+          <Text size="xs" c="dimmed" ff="monospace" mb="xs">
+            {upgrade.description}
+          </Text>
 
-      <Group justify="space-between" align="center">
-        <Text size="xs" ff="monospace" c="yellow">
-          +{upgrade.clickSeconds}s per click
-        </Text>
-        {!purchased && (
-          <Button
-            size="compact-xs"
-            variant={canAfford ? "filled" : "default"}
-            color="green"
-            disabled={!canAfford}
-            onClick={handlePurchase}
-            ff="monospace"
-          >
-            {formatNumber(upgrade.cost)} TD
-          </Button>
-        )}
-      </Group>
-    </Card>
+          <Group justify="space-between" align="center">
+            <Text size="xs" ff="monospace" c="yellow">
+              +{upgrade.clickSeconds}s per click
+            </Text>
+            {!purchased && (
+              <Button
+                size="compact-xs"
+                variant={canAfford ? "filled" : "default"}
+                color="green"
+                disabled={!canAfford}
+                onClick={handlePurchase}
+                ff="monospace"
+              >
+                {formatNumber(upgrade.cost)} TD
+              </Button>
+            )}
+          </Group>
+        </Card>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <ClickUpgradeTooltipContent upgrade={upgrade} purchased={purchased} />
+      </Popover.Dropdown>
+    </Popover>
   );
 }

--- a/src/components/upgrades/ClickUpgradeTooltipContent.tsx
+++ b/src/components/upgrades/ClickUpgradeTooltipContent.tsx
@@ -1,0 +1,53 @@
+import { Badge, Divider, Group, Stack, Text } from "@mantine/core";
+import type { ClickUpgrade } from "../../data/clickUpgrades";
+import { formatNumber } from "../../utils/formatNumber";
+
+interface ClickUpgradeTooltipContentProps {
+  upgrade: ClickUpgrade;
+  purchased: boolean;
+}
+
+export function ClickUpgradeTooltipContent({
+  upgrade,
+  purchased,
+}: ClickUpgradeTooltipContentProps) {
+  return (
+    <Stack gap="xs" w={210}>
+      <Group justify="space-between" wrap="nowrap">
+        <Text size="sm" fw={700} ff="monospace">
+          {upgrade.icon} {upgrade.name}
+        </Text>
+        {purchased && (
+          <Badge size="xs" variant="light" color="yellow">
+            OWNED
+          </Badge>
+        )}
+      </Group>
+      <Divider />
+
+      <Text size="xs" c="dimmed" ff="monospace">
+        {upgrade.description}
+      </Text>
+
+      <Group justify="space-between">
+        <Text size="xs" c="dimmed" ff="monospace">
+          Effect
+        </Text>
+        <Text size="xs" c="yellow" ff="monospace">
+          +{upgrade.clickSeconds}s per click
+        </Text>
+      </Group>
+
+      {!purchased && (
+        <Group justify="space-between">
+          <Text size="xs" c="dimmed" ff="monospace">
+            Cost
+          </Text>
+          <Text size="xs" ff="monospace">
+            {formatNumber(upgrade.cost)} TD
+          </Text>
+        </Group>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/upgrades/GeneratorTooltipContent.tsx
+++ b/src/components/upgrades/GeneratorTooltipContent.tsx
@@ -1,0 +1,105 @@
+import { Box, Divider, Group, Progress, Stack, Text } from "@mantine/core";
+import type { Upgrade } from "../../data/upgrades";
+import { formatNumber } from "../../utils/formatNumber";
+import { computeGeneratorTooltipData } from "./tooltipHelpers";
+
+interface GeneratorTooltipContentProps {
+  upgrade: Upgrade;
+  owned: number;
+  allOwned: Record<string, number>;
+}
+
+export function GeneratorTooltipContent({
+  upgrade,
+  owned,
+  allOwned,
+}: GeneratorTooltipContentProps) {
+  const {
+    baseTdPerUnit,
+    milestoneMultiplier,
+    synergyMultiplier,
+    effectiveTdPerUnit,
+    totalTdForGenerator,
+    percentOfTotal,
+    nextMilestoneOwned,
+    nextMilestoneMultiplier,
+  } = computeGeneratorTooltipData(upgrade, owned, allOwned);
+
+  const hasMultiplier = milestoneMultiplier > 1 || synergyMultiplier > 1;
+
+  return (
+    <Stack gap="xs" w={220}>
+      <Text size="sm" fw={700} ff="monospace">
+        {upgrade.icon} {upgrade.name}
+      </Text>
+      <Divider />
+
+      <Group justify="space-between">
+        <Text size="xs" c="dimmed" ff="monospace">
+          Owned
+        </Text>
+        <Text size="xs" fw={600} ff="monospace">
+          {owned}
+        </Text>
+      </Group>
+
+      <Group justify="space-between">
+        <Text size="xs" c="dimmed" ff="monospace">
+          Base TD/s (per unit)
+        </Text>
+        <Text size="xs" ff="monospace">
+          {formatNumber(baseTdPerUnit)}
+        </Text>
+      </Group>
+
+      {hasMultiplier && (
+        <Group justify="space-between">
+          <Text size="xs" c="dimmed" ff="monospace">
+            Effective TD/s (per unit)
+          </Text>
+          <Text size="xs" c="green" ff="monospace">
+            {formatNumber(effectiveTdPerUnit)}
+          </Text>
+        </Group>
+      )}
+
+      <Group justify="space-between">
+        <Text size="xs" c="dimmed" ff="monospace">
+          Total TD/s
+        </Text>
+        <Text size="xs" c="green" fw={600} ff="monospace">
+          {formatNumber(totalTdForGenerator)}
+        </Text>
+      </Group>
+
+      {percentOfTotal > 0 && (
+        <Box>
+          <Group justify="space-between" mb={4}>
+            <Text size="xs" c="dimmed" ff="monospace">
+              % of total TD/s
+            </Text>
+            <Text size="xs" ff="monospace">
+              {percentOfTotal.toFixed(1)}%
+            </Text>
+          </Group>
+          <Progress
+            value={percentOfTotal}
+            size="xs"
+            color="green"
+            radius="xl"
+          />
+        </Box>
+      )}
+
+      {nextMilestoneOwned !== null && (
+        <>
+          <Divider />
+          <Text size="xs" c="yellow" ff="monospace">
+            Next milestone: {nextMilestoneOwned} owned &rarr; &times;
+            {nextMilestoneMultiplier} production
+          </Text>
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/upgrades/UpgradeCard.tsx
+++ b/src/components/upgrades/UpgradeCard.tsx
@@ -1,4 +1,12 @@
-import { Badge, Button, Card, Group, Text } from "@mantine/core";
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Card,
+  Group,
+  Popover,
+  Text,
+} from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { MILESTONE_THRESHOLDS } from "../../data/milestones";
@@ -13,6 +21,7 @@ import { getBulkCost, getMaxAffordable } from "../../engine/upgradeEngine";
 import { useReducedMotion } from "../../hooks/useReducedMotion";
 import type { BuyMode } from "../../store/settingsStore";
 import { formatNumber } from "../../utils/formatNumber";
+import { GeneratorTooltipContent } from "./GeneratorTooltipContent";
 
 interface UpgradeCardProps {
   upgrade: Upgrade;
@@ -47,6 +56,8 @@ export function UpgradeCard({
 
   const [isGlowing, setIsGlowing] = useState(false);
   const [isMilestoneGlowing, setIsMilestoneGlowing] = useState(false);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const isHoverDevice = useRef(false);
   const glowTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const milestoneGlowTimerRef =
     useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -118,80 +129,119 @@ export function UpgradeCard({
     upgrade.baseTdPerSecond * milestoneMultiplier * synergyMultiplier;
 
   return (
-    <Card
-      className={isAnimating ? "glow-pulse" : undefined}
-      padding="sm"
-      radius="sm"
-      withBorder
-      aria-disabled={!canAfford ? "true" : undefined}
-      style={{
-        borderColor: isMilestoneGlowing
-          ? "var(--mantine-color-yellow-6)"
-          : canAfford
-            ? "var(--mantine-color-green-8)"
-            : "var(--mantine-color-dark-4)",
-        opacity: canAfford ? 1 : 0.5,
-        animation: isAnimating ? "glow-pulse 0.6s ease-in-out" : undefined,
-      }}
+    <Popover
+      opened={tooltipOpen}
+      onChange={setTooltipOpen}
+      position="right"
+      withArrow
+      shadow="md"
+      withinPortal
     >
-      <Group justify="space-between" mb={4}>
-        <Text size="sm" fw={700} ff="monospace">
-          {upgrade.icon} {upgrade.name}
-        </Text>
-        <Badge size="sm" variant="light" color="green">
-          x{owned}
-        </Badge>
-      </Group>
-
-      <Text size="xs" c="dimmed" ff="monospace" mb={4}>
-        {upgrade.description}
-      </Text>
-
-      {/* Milestone dots + progress toward next threshold */}
-      <Group gap={6} mb="xs" align="center">
-        {MILESTONE_THRESHOLDS.map((t) => (
-          <Text
-            key={t.owned}
-            size="xs"
-            c={owned >= t.owned ? "yellow" : "dimmed"}
-            title={`${t.owned} owned: ×${t.multiplier} (${t.label})`}
-            style={{ lineHeight: 1 }}
-          >
-            {owned >= t.owned ? "●" : "○"}
-          </Text>
-        ))}
-        <Text size="xs" ff="monospace" c="dimmed">
-          {nextThreshold ? `${owned}/${nextThreshold.owned}` : "✦ MAX"}
-        </Text>
-      </Group>
-
-      <Group justify="space-between" align="center">
-        <Group gap={4} align="center">
-          <Text size="xs" ff="monospace" c="green">
-            +{formatNumber(effectiveTdPerSecond)} TD/s
-          </Text>
-          {milestoneMultiplier > 1 && (
-            <Badge size="xs" variant="light" color="yellow">
-              ×{milestoneMultiplier}
-            </Badge>
-          )}
-          {synergyMultiplier > 1 && (
-            <Badge size="xs" variant="light" color="cyan">
-              ⚡×{synergyMultiplier}
-            </Badge>
-          )}
-        </Group>
-        <Button
-          size="compact-xs"
-          variant={canAfford ? "filled" : "default"}
-          color="green"
-          disabled={!canAfford}
-          onClick={handlePurchase}
-          ff="monospace"
+      <Popover.Target>
+        <Card
+          onMouseEnter={() => {
+            isHoverDevice.current = true;
+            setTooltipOpen(true);
+          }}
+          onMouseLeave={() => setTooltipOpen(false)}
+          className={isAnimating ? "glow-pulse" : undefined}
+          padding="sm"
+          radius="sm"
+          withBorder
+          aria-disabled={!canAfford ? "true" : undefined}
+          style={{
+            borderColor: isMilestoneGlowing
+              ? "var(--mantine-color-yellow-6)"
+              : canAfford
+                ? "var(--mantine-color-green-8)"
+                : "var(--mantine-color-dark-4)",
+            opacity: canAfford ? 1 : 0.5,
+            animation: isAnimating ? "glow-pulse 0.6s ease-in-out" : undefined,
+          }}
         >
-          {buyLabel}
-        </Button>
-      </Group>
-    </Card>
+          <Group justify="space-between" mb={4} wrap="nowrap">
+            <Text size="sm" fw={700} ff="monospace">
+              {upgrade.icon} {upgrade.name}
+            </Text>
+            <Group gap={4} wrap="nowrap">
+              <Badge size="sm" variant="light" color="green">
+                x{owned}
+              </Badge>
+              <ActionIcon
+                size="xs"
+                variant="subtle"
+                color="gray"
+                aria-label={`Show details for ${upgrade.name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!isHoverDevice.current) {
+                    setTooltipOpen((o) => !o);
+                  }
+                }}
+              >
+                ℹ
+              </ActionIcon>
+            </Group>
+          </Group>
+
+          <Text size="xs" c="dimmed" ff="monospace" mb={4}>
+            {upgrade.description}
+          </Text>
+
+          {/* Milestone dots + progress toward next threshold */}
+          <Group gap={6} mb="xs" align="center">
+            {MILESTONE_THRESHOLDS.map((t) => (
+              <Text
+                key={t.owned}
+                size="xs"
+                c={owned >= t.owned ? "yellow" : "dimmed"}
+                title={`${t.owned} owned: ×${t.multiplier} (${t.label})`}
+                style={{ lineHeight: 1 }}
+              >
+                {owned >= t.owned ? "\u25CF" : "\u25CB"}
+              </Text>
+            ))}
+            <Text size="xs" ff="monospace" c="dimmed">
+              {nextThreshold ? `${owned}/${nextThreshold.owned}` : "\u2746 MAX"}
+            </Text>
+          </Group>
+
+          <Group justify="space-between" align="center">
+            <Group gap={4} align="center">
+              <Text size="xs" ff="monospace" c="green">
+                +{formatNumber(effectiveTdPerSecond)} TD/s
+              </Text>
+              {milestoneMultiplier > 1 && (
+                <Badge size="xs" variant="light" color="yellow">
+                  ×{milestoneMultiplier}
+                </Badge>
+              )}
+              {synergyMultiplier > 1 && (
+                <Badge size="xs" variant="light" color="cyan">
+                  ⚡×{synergyMultiplier}
+                </Badge>
+              )}
+            </Group>
+            <Button
+              size="compact-xs"
+              variant={canAfford ? "filled" : "default"}
+              color="green"
+              disabled={!canAfford}
+              onClick={handlePurchase}
+              ff="monospace"
+            >
+              {buyLabel}
+            </Button>
+          </Group>
+        </Card>
+      </Popover.Target>
+      <Popover.Dropdown>
+        <GeneratorTooltipContent
+          upgrade={upgrade}
+          owned={owned}
+          allOwned={allOwned}
+        />
+      </Popover.Dropdown>
+    </Popover>
   );
 }

--- a/src/components/upgrades/tooltipHelpers.test.ts
+++ b/src/components/upgrades/tooltipHelpers.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { UPGRADES } from "../../data/upgrades";
+import { computeGeneratorTooltipData } from "./tooltipHelpers";
+
+const neuralNotepad = UPGRADES.find((u) => u.id === "neural-notepad");
+if (!neuralNotepad)
+  throw new Error("neural-notepad upgrade not found in UPGRADES");
+const hamsterWheel = UPGRADES.find((u) => u.id === "data-hamster-wheel");
+if (!hamsterWheel)
+  throw new Error("data-hamster-wheel upgrade not found in UPGRADES");
+
+describe("computeGeneratorTooltipData", () => {
+  it("returns baseline values with 0 owned", () => {
+    const data = computeGeneratorTooltipData(neuralNotepad, 0, {});
+    expect(data.owned).toBe(0);
+    expect(data.baseTdPerUnit).toBe(0.1);
+    expect(data.milestoneMultiplier).toBe(1);
+    expect(data.synergyMultiplier).toBe(1);
+    expect(data.effectiveTdPerUnit).toBe(0.1);
+    expect(data.totalTdForGenerator).toBe(0);
+    expect(data.percentOfTotal).toBe(0);
+  });
+
+  it("shows next milestone threshold at 10 when owned < 10", () => {
+    const data = computeGeneratorTooltipData(neuralNotepad, 5, {
+      "neural-notepad": 5,
+    });
+    expect(data.nextMilestoneOwned).toBe(10);
+    expect(data.nextMilestoneMultiplier).toBe(1.5);
+    expect(data.nextMilestoneLabel).toBe("+50%");
+  });
+
+  it("applies x1.5 milestone multiplier at 10 owned", () => {
+    const allOwned = { "neural-notepad": 10 };
+    const data = computeGeneratorTooltipData(neuralNotepad, 10, allOwned);
+    expect(data.milestoneMultiplier).toBe(1.5);
+    expect(data.effectiveTdPerUnit).toBeCloseTo(0.1 * 1.5);
+    expect(data.totalTdForGenerator).toBeCloseTo(0.1 * 1.5 * 10);
+    expect(data.nextMilestoneOwned).toBe(25);
+  });
+
+  it("applies x2 milestone multiplier at 25 owned", () => {
+    const allOwned = { "neural-notepad": 25 };
+    const data = computeGeneratorTooltipData(neuralNotepad, 25, allOwned);
+    expect(data.milestoneMultiplier).toBe(2);
+    expect(data.nextMilestoneOwned).toBe(50);
+  });
+
+  it("applies x3 milestone multiplier at 50 owned", () => {
+    const allOwned = { "neural-notepad": 50 };
+    const data = computeGeneratorTooltipData(neuralNotepad, 50, allOwned);
+    expect(data.milestoneMultiplier).toBe(3);
+    expect(data.nextMilestoneOwned).toBe(100);
+  });
+
+  it("returns null next milestone when at max milestone (100 owned)", () => {
+    const allOwned = { "neural-notepad": 100 };
+    const data = computeGeneratorTooltipData(neuralNotepad, 100, allOwned);
+    expect(data.milestoneMultiplier).toBe(6);
+    expect(data.nextMilestoneOwned).toBeNull();
+    expect(data.nextMilestoneMultiplier).toBeNull();
+    expect(data.nextMilestoneLabel).toBeNull();
+  });
+
+  it("shows 100% when only one generator type is owned", () => {
+    const allOwned = { "neural-notepad": 5 };
+    const data = computeGeneratorTooltipData(neuralNotepad, 5, allOwned);
+    expect(data.percentOfTotal).toBeCloseTo(100);
+  });
+
+  it("computes correct % share with two generators", () => {
+    // notepad: 5 x 0.1 = 0.5 TD/s, hamster: 5 x 0.5 = 2.5 TD/s, total = 3.0
+    const allOwned = {
+      "neural-notepad": 5,
+      "data-hamster-wheel": 5,
+    };
+    const notepadData = computeGeneratorTooltipData(neuralNotepad, 5, allOwned);
+    const hamsterData = computeGeneratorTooltipData(hamsterWheel, 5, allOwned);
+    expect(notepadData.percentOfTotal).toBeCloseTo((0.5 / 3.0) * 100, 1);
+    expect(hamsterData.percentOfTotal).toBeCloseTo((2.5 / 3.0) * 100, 1);
+    expect(notepadData.percentOfTotal + hamsterData.percentOfTotal).toBeCloseTo(
+      100,
+      1,
+    );
+  });
+
+  it("returns correct name and icon", () => {
+    const data = computeGeneratorTooltipData(neuralNotepad, 0, {});
+    expect(data.name).toBe("Neural Notepad");
+    expect(data.icon).toBe("\uD83D\uDCDD");
+  });
+
+  it("effectiveTdPerUnit equals baseTdPerUnit when no multipliers apply", () => {
+    const data = computeGeneratorTooltipData(neuralNotepad, 3, {
+      "neural-notepad": 3,
+    });
+    expect(data.effectiveTdPerUnit).toBeCloseTo(data.baseTdPerUnit);
+  });
+
+  it("totalTdForGenerator is effectiveTdPerUnit x owned", () => {
+    const allOwned = { "neural-notepad": 10 };
+    const data = computeGeneratorTooltipData(neuralNotepad, 10, allOwned);
+    expect(data.totalTdForGenerator).toBeCloseTo(
+      data.effectiveTdPerUnit * data.owned,
+    );
+  });
+});

--- a/src/components/upgrades/tooltipHelpers.ts
+++ b/src/components/upgrades/tooltipHelpers.ts
@@ -1,0 +1,67 @@
+import { MILESTONE_THRESHOLDS } from "../../data/milestones";
+import type { Upgrade } from "../../data/upgrades";
+import { UPGRADES } from "../../data/upgrades";
+import {
+  getMilestoneLevel,
+  getMilestoneMultiplier,
+} from "../../engine/milestoneEngine";
+import { getSynergyMultiplier } from "../../engine/synergyEngine";
+import { getTotalTdPerSecond } from "../../engine/upgradeEngine";
+
+export interface GeneratorTooltipData {
+  name: string;
+  icon: string;
+  owned: number;
+  baseTdPerUnit: number;
+  milestoneMultiplier: number;
+  synergyMultiplier: number;
+  effectiveTdPerUnit: number;
+  totalTdForGenerator: number;
+  percentOfTotal: number;
+  nextMilestoneOwned: number | null;
+  nextMilestoneMultiplier: number | null;
+  nextMilestoneLabel: string | null;
+}
+
+/**
+ * Computes all data needed to render the rich generator tooltip.
+ * Global multipliers (idle boost, species, booster) are excluded from
+ * per-generator values because they apply equally to all generators,
+ * keeping the percentage calculation correct regardless of global bonuses.
+ */
+export function computeGeneratorTooltipData(
+  upgrade: Upgrade,
+  owned: number,
+  allOwned: Record<string, number>,
+): GeneratorTooltipData {
+  const milestoneLevel = getMilestoneLevel(owned);
+  const milestoneMultiplier = getMilestoneMultiplier(owned);
+  const synergyMultiplier = getSynergyMultiplier(upgrade.id, allOwned);
+  const effectiveTdPerUnit =
+    upgrade.baseTdPerSecond * milestoneMultiplier * synergyMultiplier;
+  const totalTdForGenerator = effectiveTdPerUnit * owned;
+
+  // Use globalMultiplier=1 and boosterMultiplier=1 so the global bonuses
+  // cancel out in the percentage calculation — the % share is the same
+  // regardless of which global multipliers are active.
+  const grandTotal = getTotalTdPerSecond(UPGRADES, allOwned, 1, 1);
+  const percentOfTotal =
+    grandTotal > 0 ? (totalTdForGenerator / grandTotal) * 100 : 0;
+
+  const nextThreshold = MILESTONE_THRESHOLDS[milestoneLevel] ?? null;
+
+  return {
+    name: upgrade.name,
+    icon: upgrade.icon,
+    owned,
+    baseTdPerUnit: upgrade.baseTdPerSecond,
+    milestoneMultiplier,
+    synergyMultiplier,
+    effectiveTdPerUnit,
+    totalTdForGenerator,
+    percentOfTotal,
+    nextMilestoneOwned: nextThreshold?.owned ?? null,
+    nextMilestoneMultiplier: nextThreshold?.multiplier ?? null,
+    nextMilestoneLabel: nextThreshold?.label ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

CI has been failing on `main` since PR #110 (tooltip feature, commit `9f7ec0e`) merged. The `npm run lint` (`biome check .`) step exits with 5 errors.

**Root causes and fixes:**

| # | File | Rule | Fix |
|---|------|------|-----|
| 1 | `UpgradeCard.tsx` | `lint/a11y/noStaticElementInteractions` | Removed bare `<div>` wrapper around `Popover.Target` — moved `onMouseEnter`/`onMouseLeave` directly onto `Card` (Mantine forwards HTML props & ref) |
| 2 | `ClickUpgradeCard.tsx` | `lint/a11y/noStaticElementInteractions` | Same fix |
| 3 | `ClickUpgradeCard.tsx` | Formatter | Inline two-prop `<ClickUpgradeTooltipContent />` self-closing element to fit within 80-char line width |
| 4 | `GeneratorTooltipContent.tsx` | Formatter | Reflow JSX text around `&rarr;`/`&times;` entities to Biome's expected line-break position |
| 5 | `tooltipHelpers.test.ts` | `lint/style/noNonNullAssertion` + Formatter | Replace `!` non-null assertions with runtime `throw` guards (TypeScript narrows the type after the throw); inline two function calls that fit on one line |

## Testing

- `npm run lint` — exits 0, no errors or warnings
- `npm test` — all 595 tests pass

## Notes

The `<div>` → `Card` refactor is safe: Mantine's `Card` is built with `polymorphicFactory`, forwards its ref, and accepts all standard HTML `div` props including `onMouseEnter`/`onMouseLeave`. The hover-open/touch-toggle behaviour of the popover is unchanged.

Fixes the CI failure introduced by #110.

-- Devon (HiveLabs developer agent)