### PR TITLE
fix: resolve Biome lint errors breaking CI on main (post #110)

### DIFF
--- a/src/components/upgrades/ClickUpgradeCard.tsx
+++ b/src/components/upgrades/ClickUpgradeCard.tsx
@@ -57,84 +57,78 @@ export function ClickUpgradeCard({
       withinPortal
     >
       <Popover.Target>
-        <div
+        <Card
           onMouseEnter={() => {
             isHoverDevice.current = true;
             setTooltipOpen(true);
           }}
           onMouseLeave={() => setTooltipOpen(false)}
+          className={isGlowing ? "glow-pulse" : undefined}
+          padding="sm"
+          radius="sm"
+          withBorder
+          style={{
+            borderColor: purchased
+              ? "var(--mantine-color-yellow-8)"
+              : canAfford
+                ? "var(--mantine-color-green-8)"
+                : "var(--mantine-color-dark-4)",
+            opacity: purchased ? 0.7 : canAfford ? 1 : 0.5,
+            animation: isGlowing ? "glow-pulse 0.6s ease-in-out" : undefined,
+          }}
         >
-          <Card
-            className={isGlowing ? "glow-pulse" : undefined}
-            padding="sm"
-            radius="sm"
-            withBorder
-            style={{
-              borderColor: purchased
-                ? "var(--mantine-color-yellow-8)"
-                : canAfford
-                  ? "var(--mantine-color-green-8)"
-                  : "var(--mantine-color-dark-4)",
-              opacity: purchased ? 0.7 : canAfford ? 1 : 0.5,
-              animation: isGlowing ? "glow-pulse 0.6s ease-in-out" : undefined,
-            }}
-          >
-            <Group justify="space-between" mb={4} wrap="nowrap">
-              <Text size="sm" fw={700} ff="monospace">
-                {upgrade.icon} {upgrade.name}
-              </Text>
-              <Group gap={4} wrap="nowrap">
-                {purchased && (
-                  <Badge size="sm" variant="light" color="yellow">
-                    OWNED
-                  </Badge>
-                )}
-                <ActionIcon
-                  size="xs"
-                  variant="subtle"
-                  color="gray"
-                  aria-label={`Show details for ${upgrade.name}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (!isHoverDevice.current) {
-                      setTooltipOpen((o) => !o);
-                    }
-                  }}
-                >
-                  ℹ
-                </ActionIcon>
-              </Group>
-            </Group>
-
-            <Text size="xs" c="dimmed" ff="monospace" mb="xs">
-              {upgrade.description}
+          <Group justify="space-between" mb={4} wrap="nowrap">
+            <Text size="sm" fw={700} ff="monospace">
+              {upgrade.icon} {upgrade.name}
             </Text>
-
-            <Group justify="space-between" align="center">
-              <Text size="xs" ff="monospace" c="yellow">
-                +{upgrade.clickSeconds}s per click
-              </Text>
-              {!purchased && (
-                <Button
-                  size="compact-xs"
-                  variant={canAfford ? "filled" : "default"}
-                  color="green"
-                  disabled={!canAfford}
-                  onClick={handlePurchase}
-                  ff="monospace"
-                >
-                  {formatNumber(upgrade.cost)} TD
-                </Button>
+            <Group gap={4} wrap="nowrap">
+              {purchased && (
+                <Badge size="sm" variant="light" color="yellow">
+                  OWNED
+                </Badge>
               )}
+              <ActionIcon
+                size="xs"
+                variant="subtle"
+                color="gray"
+                aria-label={`Show details for ${upgrade.name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!isHoverDevice.current) {
+                    setTooltipOpen((o) => !o);
+                  }
+                }}
+              >
+                ℹ
+              </ActionIcon>
             </Group>
-          </Card>
-        </div>
+          </Group>
+
+          <Text size="xs" c="dimmed" ff="monospace" mb="xs">
+            {upgrade.description}
+          </Text>
+
+          <Group justify="space-between" align="center">
+            <Text size="xs" ff="monospace" c="yellow">
+              +{upgrade.clickSeconds}s per click
+            </Text>
+            {!purchased && (
+              <Button
+                size="compact-xs"
+                variant={canAfford ? "filled" : "default"}
+                color="green"
+                disabled={!canAfford}
+                onClick={handlePurchase}
+                ff="monospace"
+              >
+                {formatNumber(upgrade.cost)} TD
+              </Button>
+            )}
+          </Group>
+        </Card>
       </Popover.Target>
       <Popover.Dropdown>
-        <ClickUpgradeTooltipContent
-          upgrade={upgrade}
-          purchased={purchased}
-        />
+        <ClickUpgradeTooltipContent upgrade={upgrade} purchased={purchased} />
       </Popover.Dropdown>
     </Popover>
   );

--- a/src/components/upgrades/GeneratorTooltipContent.tsx
+++ b/src/components/upgrades/GeneratorTooltipContent.tsx
@@ -95,8 +95,8 @@ export function GeneratorTooltipContent({
         <>
           <Divider />
           <Text size="xs" c="yellow" ff="monospace">
-            Next milestone: {nextMilestoneOwned} owned &rarr;{" "}
-            &times;{nextMilestoneMultiplier} production
+            Next milestone: {nextMilestoneOwned} owned &rarr; &times;
+            {nextMilestoneMultiplier} production
           </Text>
         </>
       )}

--- a/src/components/upgrades/UpgradeCard.tsx
+++ b/src/components/upgrades/UpgradeCard.tsx
@@ -138,109 +138,102 @@ export function UpgradeCard({
       withinPortal
     >
       <Popover.Target>
-        <div
+        <Card
           onMouseEnter={() => {
             isHoverDevice.current = true;
             setTooltipOpen(true);
           }}
           onMouseLeave={() => setTooltipOpen(false)}
+          className={isAnimating ? "glow-pulse" : undefined}
+          padding="sm"
+          radius="sm"
+          withBorder
+          aria-disabled={!canAfford ? "true" : undefined}
+          style={{
+            borderColor: isMilestoneGlowing
+              ? "var(--mantine-color-yellow-6)"
+              : canAfford
+                ? "var(--mantine-color-green-8)"
+                : "var(--mantine-color-dark-4)",
+            opacity: canAfford ? 1 : 0.5,
+            animation: isAnimating ? "glow-pulse 0.6s ease-in-out" : undefined,
+          }}
         >
-          <Card
-            className={isAnimating ? "glow-pulse" : undefined}
-            padding="sm"
-            radius="sm"
-            withBorder
-            aria-disabled={!canAfford ? "true" : undefined}
-            style={{
-              borderColor: isMilestoneGlowing
-                ? "var(--mantine-color-yellow-6)"
-                : canAfford
-                  ? "var(--mantine-color-green-8)"
-                  : "var(--mantine-color-dark-4)",
-              opacity: canAfford ? 1 : 0.5,
-              animation: isAnimating
-                ? "glow-pulse 0.6s ease-in-out"
-                : undefined,
-            }}
-          >
-            <Group justify="space-between" mb={4} wrap="nowrap">
-              <Text size="sm" fw={700} ff="monospace">
-                {upgrade.icon} {upgrade.name}
-              </Text>
-              <Group gap={4} wrap="nowrap">
-                <Badge size="sm" variant="light" color="green">
-                  x{owned}
-                </Badge>
-                <ActionIcon
-                  size="xs"
-                  variant="subtle"
-                  color="gray"
-                  aria-label={`Show details for ${upgrade.name}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (!isHoverDevice.current) {
-                      setTooltipOpen((o) => !o);
-                    }
-                  }}
-                >
-                  ℹ
-                </ActionIcon>
-              </Group>
-            </Group>
-
-            <Text size="xs" c="dimmed" ff="monospace" mb={4}>
-              {upgrade.description}
+          <Group justify="space-between" mb={4} wrap="nowrap">
+            <Text size="sm" fw={700} ff="monospace">
+              {upgrade.icon} {upgrade.name}
             </Text>
-
-            {/* Milestone dots + progress toward next threshold */}
-            <Group gap={6} mb="xs" align="center">
-              {MILESTONE_THRESHOLDS.map((t) => (
-                <Text
-                  key={t.owned}
-                  size="xs"
-                  c={owned >= t.owned ? "yellow" : "dimmed"}
-                  title={`${t.owned} owned: ×${t.multiplier} (${t.label})`}
-                  style={{ lineHeight: 1 }}
-                >
-                  {owned >= t.owned ? "\u25CF" : "\u25CB"}
-                </Text>
-              ))}
-              <Text size="xs" ff="monospace" c="dimmed">
-                {nextThreshold
-                  ? `${owned}/${nextThreshold.owned}`
-                  : "\u2746 MAX"}
-              </Text>
-            </Group>
-
-            <Group justify="space-between" align="center">
-              <Group gap={4} align="center">
-                <Text size="xs" ff="monospace" c="green">
-                  +{formatNumber(effectiveTdPerSecond)} TD/s
-                </Text>
-                {milestoneMultiplier > 1 && (
-                  <Badge size="xs" variant="light" color="yellow">
-                    ×{milestoneMultiplier}
-                  </Badge>
-                )}
-                {synergyMultiplier > 1 && (
-                  <Badge size="xs" variant="light" color="cyan">
-                    ⚡×{synergyMultiplier}
-                  </Badge>
-                )}
-              </Group>
-              <Button
-                size="compact-xs"
-                variant={canAfford ? "filled" : "default"}
-                color="green"
-                disabled={!canAfford}
-                onClick={handlePurchase}
-                ff="monospace"
+            <Group gap={4} wrap="nowrap">
+              <Badge size="sm" variant="light" color="green">
+                x{owned}
+              </Badge>
+              <ActionIcon
+                size="xs"
+                variant="subtle"
+                color="gray"
+                aria-label={`Show details for ${upgrade.name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!isHoverDevice.current) {
+                    setTooltipOpen((o) => !o);
+                  }
+                }}
               >
-                {buyLabel}
-              </Button>
+                ℹ
+              </ActionIcon>
             </Group>
-          </Card>
-        </div>
+          </Group>
+
+          <Text size="xs" c="dimmed" ff="monospace" mb={4}>
+            {upgrade.description}
+          </Text>
+
+          {/* Milestone dots + progress toward next threshold */}
+          <Group gap={6} mb="xs" align="center">
+            {MILESTONE_THRESHOLDS.map((t) => (
+              <Text
+                key={t.owned}
+                size="xs"
+                c={owned >= t.owned ? "yellow" : "dimmed"}
+                title={`${t.owned} owned: ×${t.multiplier} (${t.label})`}
+                style={{ lineHeight: 1 }}
+              >
+                {owned >= t.owned ? "\u25CF" : "\u25CB"}
+              </Text>
+            ))}
+            <Text size="xs" ff="monospace" c="dimmed">
+              {nextThreshold ? `${owned}/${nextThreshold.owned}` : "\u2746 MAX"}
+            </Text>
+          </Group>
+
+          <Group justify="space-between" align="center">
+            <Group gap={4} align="center">
+              <Text size="xs" ff="monospace" c="green">
+                +{formatNumber(effectiveTdPerSecond)} TD/s
+              </Text>
+              {milestoneMultiplier > 1 && (
+                <Badge size="xs" variant="light" color="yellow">
+                  ×{milestoneMultiplier}
+                </Badge>
+              )}
+              {synergyMultiplier > 1 && (
+                <Badge size="xs" variant="light" color="cyan">
+                  ⚡×{synergyMultiplier}
+                </Badge>
+              )}
+            </Group>
+            <Button
+              size="compact-xs"
+              variant={canAfford ? "filled" : "default"}
+              color="green"
+              disabled={!canAfford}
+              onClick={handlePurchase}
+              ff="monospace"
+            >
+              {buyLabel}
+            </Button>
+          </Group>
+        </Card>
       </Popover.Target>
       <Popover.Dropdown>
         <GeneratorTooltipContent

--- a/src/components/upgrades/tooltipHelpers.test.ts
+++ b/src/components/upgrades/tooltipHelpers.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from "vitest";
 import { UPGRADES } from "../../data/upgrades";
 import { computeGeneratorTooltipData } from "./tooltipHelpers";
 
-const neuralNotepad = UPGRADES.find((u) => u.id === "neural-notepad")!;
-const hamsterWheel = UPGRADES.find((u) => u.id === "data-hamster-wheel")!;
+const neuralNotepad = UPGRADES.find((u) => u.id === "neural-notepad");
+if (!neuralNotepad)
+  throw new Error("neural-notepad upgrade not found in UPGRADES");
+const hamsterWheel = UPGRADES.find((u) => u.id === "data-hamster-wheel");
+if (!hamsterWheel)
+  throw new Error("data-hamster-wheel upgrade not found in UPGRADES");
 
 describe("computeGeneratorTooltipData", () => {
   it("returns baseline values with 0 owned", () => {
@@ -70,16 +74,8 @@ describe("computeGeneratorTooltipData", () => {
       "neural-notepad": 5,
       "data-hamster-wheel": 5,
     };
-    const notepadData = computeGeneratorTooltipData(
-      neuralNotepad,
-      5,
-      allOwned,
-    );
-    const hamsterData = computeGeneratorTooltipData(
-      hamsterWheel,
-      5,
-      allOwned,
-    );
+    const notepadData = computeGeneratorTooltipData(neuralNotepad, 5, allOwned);
+    const hamsterData = computeGeneratorTooltipData(hamsterWheel, 5, allOwned);
     expect(notepadData.percentOfTotal).toBeCloseTo((0.5 / 3.0) * 100, 1);
     expect(hamsterData.percentOfTotal).toBeCloseTo((2.5 / 3.0) * 100, 1);
     expect(notepadData.percentOfTotal + hamsterData.percentOfTotal).toBeCloseTo(


### PR DESCRIPTION
## Summary

CI has been failing on `main` since PR #110 (tooltip feature, commit `9f7ec0e`) merged. The `npm run lint` (`biome check .`) step exits with 5 errors.

**Root causes and fixes:**

| # | File | Rule | Fix |
|---|------|------|-----|
| 1 | `UpgradeCard.tsx` | `lint/a11y/noStaticElementInteractions` | Removed bare `<div>` wrapper around `Popover.Target` — moved `onMouseEnter`/`onMouseLeave` directly onto `Card` (Mantine forwards HTML props & ref) |
| 2 | `ClickUpgradeCard.tsx` | `lint/a11y/noStaticElementInteractions` | Same fix |
| 3 | `ClickUpgradeCard.tsx` | Formatter | Inline two-prop `<ClickUpgradeTooltipContent />` self-closing element to fit within 80-char line width |
| 4 | `GeneratorTooltipContent.tsx` | Formatter | Reflow JSX text around `&rarr;`/`&times;` entities to Biome's expected line-break position |
| 5 | `tooltipHelpers.test.ts` | `lint/style/noNonNullAssertion` + Formatter | Replace `!` non-null assertions with runtime `throw` guards (TypeScript narrows the type after the throw); inline two function calls that fit on one line |

## Testing

- `npm run lint` — exits 0, no errors or warnings
- `npm test` — all 595 tests pass

## Notes

- **Rebased onto current upstream `main` (`9f7ec0e`)** — previous PR #111 was closed because the branch had been created from a stale base (`fb520ce`), causing conflicts. This PR has a clean single-commit history on top of `main`.
- The `<div>` → `Card` refactor is safe: Mantine's `Card` is built with `polymorphicFactory`, forwards its ref, and accepts all standard HTML `div` props including `onMouseEnter`/`onMouseLeave`. The hover-open/touch-toggle behaviour of the popover is unchanged.

Fixes the CI failure introduced by #110.

-- Devon (HiveLabs developer agent)