### PR TITLE
docs: add pre-branch sync and pre-push workflow to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,35 @@ Do NOT rely on training data for version numbers. Always verify. Use exact versi
 
 ### Git Workflow
 
+Always sync with upstream before branching and validate locally before pushing — this prevents merge conflicts and catches lint/build errors before CI runs.
+
+#### Starting a new branch
+
+Sync your fork with the latest upstream `main` before creating any branch. A stale base causes avoidable merge conflicts in PRs:
+
+```bash
+git fetch upstream
+git checkout main
+git merge upstream/main --ff-only
+# If fast-forward fails (fork has diverged): git reset --hard upstream/main && git push origin main --force
+git push origin main
+git checkout -b feat/my-feature    # or fix/, chore/, docs/
+```
+
+#### Before pushing
+
+Run all three checks locally before every push. Do not push code that fails any of them — CI enforces the same rules, but fixing locally is faster and avoids broken-CI commits (see PRs #110 and #115 for past lint incidents):
+
+```bash
+npm run lint    # Biome lint + format check
+npm run test    # Full Vitest suite (623+ unit tests)
+npm run build   # Vite production build (catches TypeScript and bundling errors)
+```
+
+Use `npm run *` commands exclusively — do not invoke `npx biome check .` or `npm test` directly.
+
+#### General rules
+
 - Branch per story/issue.
 - Commit messages reference the GitHub issue number.
 - PRs target `main`. GitHub Pages auto-deploys on merge via GitHub Actions.


### PR DESCRIPTION
## Summary

- Adds a **"Starting a new branch"** subsection to `### Git Workflow` with exact commands to sync the fork with `upstream/main` before branching (prevents stale-base merge conflicts)
- Adds a **"Before pushing"** subsection with `npm run lint`, `npm run test`, and `npm run build`, plus a note to use `npm run *` exclusively
- Splits the flat bullet list into an **"#### General rules"** subsection so the new content sits prominently above it
- Brief *why* included for each step; references PRs #110 and #115 as motivation for the lint check

## Changes

- `CLAUDE.md`: expanded `### Git Workflow` section with two new subsections

## Story

Closes #116

## Testing instructions

- Read the updated `CLAUDE.md` and verify both new subsections are present and copy-pasteable
- Confirm `npm run lint`, `npm run test`, and `npm run build` commands are correct for the repo toolchain
- No source code changes; no tests required

-- Devon (HiveLabs developer agent)