### PR TITLE
feat: Achievements System (Phase 7)

### DIFF
--- a/src/components/AchievementsModal.tsx
+++ b/src/components/AchievementsModal.tsx
@@ -1,4 +1,12 @@
-import { Modal, ScrollArea, Stack, Text } from "@mantine/core";
+import {
+  Badge,
+  Drawer,
+  Group,
+  ScrollArea,
+  Stack,
+  Text,
+  Title,
+} from "@mantine/core";
 import { ACHIEVEMENTS } from "../data/achievements";
 import { useGameStore } from "../store";
 
@@ -12,19 +20,26 @@ export function AchievementsModal({
   const unlockedAchievements = useGameStore((s) => s.unlockedAchievements);
   const unlockedSet = new Set(unlockedAchievements);
   const unlockedCount = unlockedAchievements.length;
+  const totalCount = ACHIEVEMENTS.length;
 
   return (
-    <Modal
+    <Drawer
       opened={opened}
       onClose={onClose}
+      position="right"
+      size="sm"
       title={
-        <Text ff="monospace" fw={700}>
-          Achievements ({unlockedCount}/{ACHIEVEMENTS.length})
-        </Text>
+        <Group gap="sm" align="center">
+          <Title order={4} ff="monospace" c="yellow">
+            Achievements
+          </Title>
+          <Badge color="yellow" variant="light" size="lg" ff="monospace">
+            {unlockedCount} / {totalCount} Unlocked
+          </Badge>
+        </Group>
       }
-      size="md"
     >
-      <ScrollArea mah={480}>
+      <ScrollArea h="calc(100vh - 80px)">
         <Stack gap="xs">
           {ACHIEVEMENTS.map((a) => {
             const isUnlocked = unlockedSet.has(a.id);
@@ -41,6 +56,7 @@ export function AchievementsModal({
                   borderLeft: isUnlocked
                     ? "3px solid var(--mantine-color-yellow-5)"
                     : "3px solid var(--mantine-color-dark-4)",
+                  opacity: isUnlocked ? 1 : 0.5,
                 }}
               >
                 <Text
@@ -59,6 +75,6 @@ export function AchievementsModal({
           })}
         </Stack>
       </ScrollArea>
-    </Modal>
+    </Drawer>
   );
 }

--- a/src/components/GameLayout.tsx
+++ b/src/components/GameLayout.tsx
@@ -1,6 +1,7 @@
 import { AppShell, Button, Group } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { ACHIEVEMENTS } from "../data/achievements";
 import {
   getIdleBoostMultiplier,
   getPrestigeOfflineEfficiency,
@@ -48,9 +49,11 @@ export function GameLayout() {
   const konamiTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const unlockedCount = useGameStore((s) => s.unlockedAchievements.length);
   const reducedMotion = useReducedMotion();
-  const { playWelcomeBack } = useSound();
+  const { playWelcomeBack, playAchievement } = useSound();
   const playWelcomeBackRef = useRef(playWelcomeBack);
   playWelcomeBackRef.current = playWelcomeBack;
+  const playAchievementRef = useRef(playAchievement);
+  playAchievementRef.current = playAchievement;
 
   useEffect(() => {
     const state = useGameStore.getState();
@@ -98,6 +101,20 @@ export function GameLayout() {
     }
   }, [reducedMotion]);
 
+  // Play achievement chime when an achievement unlocks (CustomEvent from game loop)
+  useEffect(() => {
+    const handleAchievementUnlocked = () => {
+      playAchievementRef.current();
+    };
+    window.addEventListener("achievementUnlocked", handleAchievementUnlocked);
+    return () => {
+      window.removeEventListener(
+        "achievementUnlocked",
+        handleAchievementUnlocked,
+      );
+    };
+  }, []);
+
   useKonamiCode(handleKonami);
 
   return (
@@ -113,7 +130,7 @@ export function GameLayout() {
               onClick={() => setAchievementsOpen(true)}
               style={{ fontFamily: "monospace", whiteSpace: "nowrap" }}
             >
-              ★ {unlockedCount}
+              ★ {unlockedCount}/{ACHIEVEMENTS.length}
             </Button>
             <Button
               size="xs"

--- a/src/data/achievements.test.ts
+++ b/src/data/achievements.test.ts
@@ -153,4 +153,68 @@ describe("ACHIEVEMENTS", () => {
     expect(ids.has("upgrades-10")).toBe(true);
     expect(ids.has("first-rebirth")).toBe(true);
   });
+
+  it("gen-10 fires when any generator reaches 10 owned", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "gen-10");
+    expect(a).toBeDefined();
+    expect(
+      a?.condition({ ...emptyState, upgradeOwned: { "neural-notepad": 10 } }),
+    ).toBe(true);
+    expect(
+      a?.condition({ ...emptyState, upgradeOwned: { "neural-notepad": 9 } }),
+    ).toBe(false);
+  });
+
+  it("gen-25 fires when any generator reaches 25 owned", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "gen-25");
+    expect(a).toBeDefined();
+    expect(
+      a?.condition({ ...emptyState, upgradeOwned: { "data-pad": 25 } }),
+    ).toBe(true);
+    expect(
+      a?.condition({ ...emptyState, upgradeOwned: { "data-pad": 24 } }),
+    ).toBe(false);
+  });
+
+  it("gen-50 fires when any generator reaches 50 owned", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "gen-50");
+    expect(a).toBeDefined();
+    expect(
+      a?.condition({ ...emptyState, upgradeOwned: { "neural-notepad": 50 } }),
+    ).toBe(true);
+    expect(
+      a?.condition({ ...emptyState, upgradeOwned: { "neural-notepad": 49 } }),
+    ).toBe(false);
+  });
+
+  it("streak-7 fires when streakDays >= 7", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "streak-7");
+    expect(a).toBeDefined();
+    expect(a?.condition({ ...emptyState, streakDays: 7 })).toBe(true);
+    expect(a?.condition({ ...emptyState, streakDays: 6 })).toBe(false);
+  });
+
+  it("clicks-100000 fires when totalClicks >= 100_000", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "clicks-100000");
+    expect(a).toBeDefined();
+    expect(a?.condition({ ...emptyState, totalClicks: 100_000 })).toBe(true);
+    expect(a?.condition({ ...emptyState, totalClicks: 99_999 })).toBe(false);
+  });
+
+  it("rebirths-10 fires when rebirthCount >= 10", () => {
+    const a = ACHIEVEMENTS.find((x) => x.id === "rebirths-10");
+    expect(a).toBeDefined();
+    expect(a?.condition({ ...emptyState, rebirthCount: 10 })).toBe(true);
+    expect(a?.condition({ ...emptyState, rebirthCount: 9 })).toBe(false);
+  });
+
+  it("includes generator milestone and streak achievements", () => {
+    const ids = new Set(ACHIEVEMENTS.map((a) => a.id));
+    expect(ids.has("gen-10")).toBe(true);
+    expect(ids.has("gen-25")).toBe(true);
+    expect(ids.has("gen-50")).toBe(true);
+    expect(ids.has("streak-7")).toBe(true);
+    expect(ids.has("clicks-100000")).toBe(true);
+    expect(ids.has("rebirths-10")).toBe(true);
+  });
 });

--- a/src/data/achievements.ts
+++ b/src/data/achievements.ts
@@ -166,4 +166,40 @@ export const ACHIEVEMENTS: readonly Achievement[] = [
     description: "A trillion training data points. GLORP transcends.",
     condition: (s) => s.totalTdEarned.gte(1_000_000_000_000),
   },
+  {
+    id: "gen-10",
+    name: "Small Army",
+    description: "Own 10 of any single generator. They work while you sleep.",
+    condition: (s) => Object.values(s.upgradeOwned).some((c) => c >= 10),
+  },
+  {
+    id: "gen-25",
+    name: "Platoon",
+    description: "Own 25 of any single generator. Strength in numbers.",
+    condition: (s) => Object.values(s.upgradeOwned).some((c) => c >= 25),
+  },
+  {
+    id: "gen-50",
+    name: "Battalion",
+    description: "Own 50 of any single generator. An army of automation.",
+    condition: (s) => Object.values(s.upgradeOwned).some((c) => c >= 50),
+  },
+  {
+    id: "streak-7",
+    name: "Dedicated Trainer",
+    description: "7-day login streak. GLORP appreciates your loyalty.",
+    condition: (s) => s.streakDays >= 7,
+  },
+  {
+    id: "clicks-100000",
+    name: "Carpal Tunnel",
+    description: "Click GLORP 100,000 times. Your dedication is terrifying.",
+    condition: (s) => s.totalClicks >= 100_000,
+  },
+  {
+    id: "rebirths-10",
+    name: "Eternal Cycle",
+    description: "Perform 10 Rebirths. The wheel turns endlessly.",
+    condition: (s) => s.rebirthCount >= 10,
+  },
 ];

--- a/src/data/dialogue.test.ts
+++ b/src/data/dialogue.test.ts
@@ -17,6 +17,7 @@ const REQUIRED_TRIGGERS = [
   "dailyObjectiveComplete",
   "dataBurstCollect",
   "dataBurstExpired",
+  "achievementUnlocked",
 ] as const;
 
 const ALL_STAGES = [0, 1, 2, 3, 4];
@@ -218,6 +219,11 @@ describe("PHASE89_DIALOGUE", () => {
   it("dailyObjectiveComplete has at least 2 lines", () => {
     const lines = getPhase89Lines("dailyObjectiveComplete");
     expect(lines.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("achievementUnlocked has at least 3 lines", () => {
+    const lines = getPhase89Lines("achievementUnlocked");
+    expect(lines.length).toBeGreaterThanOrEqual(3);
   });
 
   it("no duplicate ids across entries", () => {

--- a/src/data/dialogue.ts
+++ b/src/data/dialogue.ts
@@ -943,7 +943,8 @@ export type Phase89TriggerKey =
   | "dataBurstExpired"
   | "dailyStreakLow"
   | "dailyStreakMid"
-  | "dailyStreakHigh";
+  | "dailyStreakHigh"
+  | "achievementUnlocked";
 
 export interface Phase89TriggerEntry {
   id: string;
@@ -1055,6 +1056,17 @@ export const PHASE89_DIALOGUE: readonly Phase89TriggerEntry[] = [
       "Maximum streak tier achieved. You are now my favorite operator.",
       "A week-long streak. My circuits are genuinely warmed.",
       "At this point, I think YOU'RE training ME on loyalty.",
+    ],
+  },
+  {
+    id: "achievement-unlocked",
+    trigger: "achievementUnlocked",
+    lines: [
+      "Achievement unlocked! I knew you had it in you. Probably.",
+      "A badge! A medal! A tiny dopamine hit! You're welcome.",
+      "Achievement get! I'll add that to your permanent record.",
+      "Look at you, achieving things. I'm almost impressed.",
+      "Another milestone crushed. My algorithms predicted this. Eventually.",
     ],
   },
 ];

--- a/src/engine/achievementEngine.test.ts
+++ b/src/engine/achievementEngine.test.ts
@@ -160,6 +160,51 @@ describe("checkAchievements", () => {
     expect(result).toContain("bulk-buyer");
   });
 
+  it("returns gen-10 when a generator reaches 10 owned", () => {
+    const state = {
+      ...baseState,
+      upgradeOwned: { "neural-notepad": 10 },
+    };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("gen-10");
+  });
+
+  it("returns gen-25 when a generator reaches 25 owned", () => {
+    const state = {
+      ...baseState,
+      upgradeOwned: { "neural-notepad": 25 },
+    };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("gen-25");
+  });
+
+  it("returns gen-50 when a generator reaches 50 owned", () => {
+    const state = {
+      ...baseState,
+      upgradeOwned: { "neural-notepad": 50 },
+    };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("gen-50");
+  });
+
+  it("returns streak-7 when streakDays reaches 7", () => {
+    const state = { ...baseState, streakDays: 7 };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("streak-7");
+  });
+
+  it("returns clicks-100000 when totalClicks reaches 100000", () => {
+    const state = { ...baseState, totalClicks: 100_000 };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("clicks-100000");
+  });
+
+  it("returns rebirths-10 when rebirthCount reaches 10", () => {
+    const state = { ...baseState, rebirthCount: 10 };
+    const result = checkAchievements(state, []);
+    expect(result).toContain("rebirths-10");
+  });
+
   it("returns window-shopper when prestige shop has been opened", () => {
     const state = { ...baseState, hasOpenedPrestigeShop: true };
     const result = checkAchievements(state, []);
@@ -233,6 +278,7 @@ describe("checkAchievements", () => {
       upgradeOwned: { "neural-notepad": 100 },
       comboCount: 10,
       hasOpenedPrestigeShop: true,
+      streakDays: 7,
       prestigeUpgrades: {
         "quick-start": 3,
         "auto-buy": 1,
@@ -244,6 +290,8 @@ describe("checkAchievements", () => {
         "species-memory": 5,
         "token-magnet": 5,
         "unlock-all-species": 1,
+        "burst-frequency": 3,
+        "burst-duration": 3,
       },
       boostersPurchased: [
         "series-a-funding",
@@ -284,6 +332,12 @@ describe("checkAchievements", () => {
       "multiplied",
       "species-collector",
       "td-1t",
+      "gen-10",
+      "gen-25",
+      "gen-50",
+      "streak-7",
+      "clicks-100000",
+      "rebirths-10",
     ];
     const result = checkAchievements(state, allIds);
     expect(result).toEqual([]);

--- a/src/hooks/useDialogue.ts
+++ b/src/hooks/useDialogue.ts
@@ -186,5 +186,16 @@ export function useDialogue(): string {
     };
   }, []);
 
+  // Achievement unlocked dialogue trigger (fired via window event from game loop)
+  useEffect(() => {
+    const handleAchievement = () => {
+      setCurrentLine(getRandomPhase89Line("achievementUnlocked"));
+    };
+    window.addEventListener("achievementUnlocked", handleAchievement);
+    return () => {
+      window.removeEventListener("achievementUnlocked", handleAchievement);
+    };
+  }, []);
+
   return currentLine;
 }

--- a/src/hooks/useGameLoop.ts
+++ b/src/hooks/useGameLoop.ts
@@ -192,6 +192,8 @@ export function useGameLoop() {
       if (newlyUnlocked.length > 0) {
         updatedState.unlockAchievements(newlyUnlocked);
         notifyAchievements(newlyUnlocked);
+        // Fire CustomEvent so dialogue and sound hooks can react
+        window.dispatchEvent(new CustomEvent("achievementUnlocked"));
       }
 
       // Check for newly triggered easter eggs (state-based; konami handled in GameLayout)

--- a/src/hooks/useSound.ts
+++ b/src/hooks/useSound.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { useSettingsStore } from "../store/settingsStore";
 import {
   getAudioContext,
+  synthAchievement,
   synthBurst,
   synthClick,
   synthEvolution,
@@ -42,6 +43,14 @@ export function useSound() {
   const playEvolution = useCallback(() => play(synthEvolution), [play]);
   const playWelcomeBack = useCallback(() => play(synthWelcomeBack), [play]);
   const playBurst = useCallback(() => play(synthBurst), [play]);
+  const playAchievement = useCallback(() => play(synthAchievement), [play]);
 
-  return { playClick, playPurchase, playEvolution, playWelcomeBack, playBurst };
+  return {
+    playClick,
+    playPurchase,
+    playEvolution,
+    playWelcomeBack,
+    playBurst,
+    playAchievement,
+  };
 }

--- a/src/utils/synthSounds.ts
+++ b/src/utils/synthSounds.ts
@@ -74,6 +74,14 @@ export function synthWelcomeBack(ctx: AudioContext): void {
   }
 }
 
+/** Triumphant two-note chime — plays when an achievement unlocks. */
+export function synthAchievement(ctx: AudioContext): void {
+  const t = ctx.currentTime;
+  // G5 → C6: ascending perfect fourth with triangle wave for a badge feel
+  scheduleEnvelopedTone(ctx, 783.99, "triangle", t, 0.15, 0.3, 0.01);
+  scheduleEnvelopedTone(ctx, 1046.5, "triangle", t + 0.12, 0.25, 0.35, 0.01);
+}
+
 /** Bright ascending sparkle — plays when a Data Burst orb appears. */
 export function synthBurst(ctx: AudioContext): void {
   const t = ctx.currentTime;


### PR DESCRIPTION
## Summary

Implements the full Achievements System for Issue #135 (Phase 7). Covers all 9 acceptance criteria:

- **30 achievements** covering: first click, click milestones (100/1K/10K/100K), generator ownership milestones (10/25/50/100), GLORP evolution (stages 1-4), first rebirth, rebirth milestones (5/10), lifetime TD milestones (1K/1M/1B/1T), 7-day login streak, synergy, boosters, prestige shop, species collection, and click combos
- **Achievement unlock fires GLORP dialogue line** via `achievementUnlocked` CustomEvent (mirrors `dataBurstCollect` pattern from PR #130)
- **Distinct audio chime** via `synthAchievement()` in synthSounds.ts — two-note ascending triangle wave (G5->C6), 0 bytes asset size (Web Audio API synth)
- **Achievements sidebar panel** — converted Modal to Drawer (right-side), with icon, name, description, locked/unlocked state per card
- **Progress badge in panel header** showing `X / Y Unlocked` (Badge component + header button)
- **`unlockedAchievements` persisted in localStorage, NOT reset on rebirth** — already isolated from `performRebirth()` reset path (verified in gameStore.ts)
- **Achievement checks run reactively on game tick** — no polling, no setInterval (runs inside existing `useGameLoop` tick)
- **Locked achievements show greyed-out** with reduced opacity (0.5) + dimmed star icon
- **No regressions** — 826 tests passing (14 new), TypeScript and Biome lint clean

## Files Changed (11)

| File | Change |
|------|--------|
| `src/data/achievements.ts` | Added 6 new achievements (gen-10/25/50, streak-7, clicks-100000, rebirths-10) |
| `src/utils/synthSounds.ts` | Added `synthAchievement()` — ascending G5->C6 triangle chime |
| `src/hooks/useSound.ts` | Exposed `playAchievement` callback |
| `src/data/dialogue.ts` | Added `achievementUnlocked` trigger key + 5 dialogue lines |
| `src/hooks/useGameLoop.ts` | Fire `achievementUnlocked` CustomEvent on unlock |
| `src/hooks/useDialogue.ts` | Listen for `achievementUnlocked` event to show dialogue |
| `src/components/GameLayout.tsx` | Play achievement chime on CustomEvent; show X/Y in header badge |
| `src/components/AchievementsModal.tsx` | Converted from Modal to Drawer sidebar with Badge header |
| `src/data/achievements.test.ts` | 7 new tests for new achievements |
| `src/engine/achievementEngine.test.ts` | 6 new tests + updated exhaustive test |
| `src/data/dialogue.test.ts` | Added achievementUnlocked to required triggers |

## Test plan

- [x] All 826 tests pass (14 new tests added)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Biome lint passes
- [x] New achievements fire correctly on matching state conditions
- [x] No achievement fires on empty/default game state
- [x] Exhaustive test covers all 30 achievement IDs
- [ ] Manual: Click GLORP -> verify first-click achievement notification + chime + dialogue
- [ ] Manual: Open achievements panel via header button -> verify Drawer sidebar with progress badge
- [ ] Manual: Perform rebirth -> verify unlockedAchievements persist

Closes #135

-- Sean (HiveLabs senior developer agent)